### PR TITLE
Reformat all paragraphs to be 80 characters wide

### DIFF
--- a/accounts.rst
+++ b/accounts.rst
@@ -3,9 +3,9 @@
 Accounts You'll Need
 ====================
 
-Most of the Mozilla web development process takes place between Bugzilla,
-IRC, and GitHub. There are some other accounts you might need too. Here's
-everything you should request when you start at Mozilla:
+Most of the Mozilla web development process takes place between Bugzilla, IRC,
+and GitHub. There are some other accounts you might need too. Here's everything
+you should request when you start at Mozilla:
 
 List of All Accounts (and How to Get Them)
 ------------------------------------------
@@ -16,33 +16,33 @@ Use the links to each app to get to their signup form.
 
   See :ref:`communications-chapter` for details.
 
-* `Bugzilla`_ — use your @mozilla.com email to get 1337 access, and
-  put your IRC nick or whatever you go by in your Bugzilla username
-  for easier searching (example: ``Matthew Riley MacPherson
-  [:tofumatt]``).
+* `Bugzilla`_ — use your @mozilla.com email to get 1337 access, and put your IRC
+  nick or whatever you go by in your Bugzilla username for easier searching
+  (example: ``Matthew Riley MacPherson [:tofumatt]``).
 
   See :ref:`bugzilla-chapter` for more details.
 
 * `GitHub`_ — a free account is all that's required to develop on Mozilla web
   apps/sites.
 
-  Ping ``wenzel``, ``jsocol``, or your manager on IRC to get added to the right groups.
+  Ping ``wenzel``, ``jsocol``, or your manager on IRC to get added to the right
+  groups.
 
   See :ref:`git-chapter` for more details.
 
-* IRC_ — check out the wiki to learn about Mozilla IRC. You should
-  register your main nickname on IRC so it doesn't get stolen and so
-  you can access any channels that require you to ``IDENTIFY``.
+* IRC_ — check out the wiki to learn about Mozilla IRC. You should register your
+  main nickname on IRC so it doesn't get stolen and so you can access any
+  channels that require you to ``IDENTIFY``.
 
   See :ref:`irc-chapter` for more details.
 
-* Mercurial_ and ``svn`` — Sometimes things aren't in GitHub and you need to
-  use ``hg`` or ``svn``. Locale files in particular are stored in Subversion
-  for various reasons. Check out `Becoming a contributor`_ and be sure to ask
-  for "Level 2 Mercurial Access".
+* Mercurial_ and ``svn`` — Sometimes things aren't in GitHub and you need to use
+  ``hg`` or ``svn``. Locale files in particular are stored in Subversion for
+  various reasons. Check out `Becoming a contributor`_ and be sure to ask for
+  "Level 2 Mercurial Access".
 
-* VPN — You'll have access to Mozilla-MV_ (office network) by default, though
-  it does require some setup. Access to Mozilla-MPT_ is by request only however,
+* VPN — You'll have access to Mozilla-MV_ (office network) by default, though it
+  does require some setup. Access to Mozilla-MPT_ is by request only however,
   and you'll need it.
 
   See :ref:`vpn-info` for more details.

--- a/bugzilla.rst
+++ b/bugzilla.rst
@@ -5,18 +5,15 @@
 Bugzilla
 ========
 
-Almost all webdev tasks take place in
-Bugzilla_. See :ref:`bug-life`.
+Almost all webdev tasks take place in Bugzilla_. See :ref:`bug-life`.
 
 .. _Bugzilla: https://bugzilla.mozilla.org
 
 The Hacks
 ---------
 
-In order to receive
-email notifications for specific components
-you must follow the appropriate
-`QA contacts`_.
+In order to receive email notifications for specific components you must follow
+the appropriate `QA contacts`_.
 
 .. _`QA contacts`: https://bugzilla.mozilla.org/describecomponents.cgi
 
@@ -33,24 +30,24 @@ be assured they get you.
 IT Requests
 -----------
 
-`IT requests`_ are a special type of bug that the IT team can follow up. You
-can file a request for Website pushes as well as Desktop support.
+`IT requests`_ are a special type of bug that the IT team can follow up. You can
+file a request for Website pushes as well as Desktop support.
 
 .. _`IT requests`: https://bugzilla.mozilla.org/enter_bug.cgi?product=mozilla.org&format=itrequest
 
 Searches
 --------
 
-Searches in Bugzilla_ can be saved. You can also share searches with others
-and you can keep other people's shared searches in your Bugzilla view.
+Searches in Bugzilla_ can be saved. You can also share searches with others and
+you can keep other people's shared searches in your Bugzilla view.
 
 .. _bugzilla-api:
 
 Making life better
 ------------------
 
-Bugzilla_ is a wild beast that cannot be tamed.
-There are a few things that can make life easier:
+Bugzilla_ is a wild beast that cannot be tamed. There are a few things that can
+make life easier:
 
 * The `Bugzilla API`_.
 * The `Bugzilla JS`_ Jetpack.
@@ -59,5 +56,5 @@ There are a few things that can make life easier:
 .. _`Bugzilla API`: https://wiki.mozilla.org/Bugzilla:REST_API
 .. _`Bugzilla JS`: https://github.com/gkoberger/BugzillaJS
 
-You can forward some or all of your email to gmail and make use of a rich set
-of filters.
+You can forward some or all of your email to gmail and make use of a rich set of
+filters.

--- a/coding.rst
+++ b/coding.rst
@@ -1,8 +1,8 @@
 How to Code
 ===========
 
-In general, follow the languages established best practices, and fill
-in the gaps where there are holes.
+In general, follow the languages established best practices, and fill in the
+gaps where there are holes.
 
 
 .. index:: code;guidelines
@@ -12,9 +12,8 @@ General Guidelines
 
 * *Style matters*
 
-  How code is aligned matters, because code is reviewed, edited, and
-  public. Code that is uneasy to read does not align with the spirit
-  of open source.
+  How code is aligned matters, because code is reviewed, edited, and public.
+  Code that is uneasy to read does not align with the spirit of open source.
 
 * *Be consistent*
 
@@ -23,8 +22,7 @@ General Guidelines
 
 * *Follow code around you*
 
-  If you don't know what you're doing try to follow what others have
-  done.
+  If you don't know what you're doing try to follow what others have done.
 
 
 .. index:: code;testing
@@ -32,8 +30,7 @@ General Guidelines
 Testing
 ^^^^^^^
 
-In languages and frameworks that provide easy test-ability, *write
-tests!*
+In languages and frameworks that provide easy test-ability, *write tests!*
 
 Go for 80% or more coverage, especially in the following areas:
 
@@ -41,14 +38,13 @@ Go for 80% or more coverage, especially in the following areas:
 * heavily used code - e.g. landing pages, library level code
 * re-opened bugs
 
-Tests last longer than code, as they tend to define the products'
-functionality. They are valuable because they allow us to quickly
-make changes without fear of hindering functionality.
+Tests last longer than code, as they tend to define the products' functionality.
+They are valuable because they allow us to quickly make changes without fear of
+hindering functionality.
 
-The other half of testing is continuous integration. We should be
-running our tests at every check in and be able to say with certainty
-that the code is correct to the best of our knowledge. See
-:ref:`ci-chapter`.
+The other half of testing is continuous integration. We should be running our
+tests at every check in and be able to say with certainty that the code is
+correct to the best of our knowledge. See :ref:`ci-chapter`.
 
 
 .. index:: code;python coding style
@@ -68,7 +64,7 @@ We do what others in the python community have established:
 Import Statements
 ^^^^^^^^^^^^^^^^^
 
-We expand on PEP8_'s suggestions for import statements.  These greatly improve 
+We expand on PEP8_'s suggestions for import statements. These greatly improve
 ones ability to ascertain what is and isn't available in a given file.
 
 Import one module per import statement::
@@ -80,8 +76,8 @@ not::
 
     import os, sys
 
-Separate imports into groups with a line of whitespace: 
-standard library; Django (or framework); third-party; and local imports::
+Separate imports into groups with a line of whitespace: standard library; Django
+(or framework); third-party; and local imports::
 
     import os
     import sys
@@ -93,7 +89,8 @@ standard library; Django (or framework); third-party; and local imports::
     from myapp import models, views
 
 
-Alphabetize your imports, it will make your code easier to scan.  See how terrible this is::
+Alphabetize your imports, it will make your code easier to scan. See how
+terrible this is::
 
     import cows
     import kittens
@@ -124,14 +121,14 @@ That's loads easier to read than::
     from zoos import lions
 
 
-Lastly, when importing things into your namespace from a package use an alphabetized
-``CONSTANT``, ``Class``, ``var`` order::
+Lastly, when importing things into your namespace from a package use an
+alphabetized ``CONSTANT``, ``Class``, ``var`` order::
 
     from models import DATE, TIME, Dog, Kitteh, upload_pets
 
 
-If possible though, it may be easier to import the entire package, especially for methods 
-as it help answers the question, "where did ``you`` come from?"
+If possible though, it may be easier to import the entire package, especially
+for methods as it help answers the question, "where did ``you`` come from?"
 
 Bad::
 
@@ -182,13 +179,12 @@ Use single quotes unless double (or triple) quotes would be an improvement::
 Django
 ------
 
-Follow :ref:`python`. There are a few things in Django that will make
-your life easier:
+Follow :ref:`python`. There are a few things in Django that will make your life
+easier:
 
-Use ``resolve('myurl')`` and ``{{ url('myurl') }}`` when linking to
-internal URLs. This will handle hosts, relative host names, changed
-end points for you. It will also noticeably break so dead-links don't
-linger in your code.
+Use ``resolve('myurl')`` and ``{{ url('myurl') }}`` when linking to internal
+URLs. This will handle hosts, relative host names, changed end points for you.
+It will also noticeably break so dead-links don't linger in your code.
 
 .. highlight:: jinja
 
@@ -204,14 +200,12 @@ Indentation within templates should be handled as such::
 Playdoh
 ^^^^^^^
 
-New web-apps should be spawned from Playdoh_ and existing ones should
-follow the spirit of Playdoh_. Playdoh_ collects lessons that several
-Mozilla Django projects have learned and wraps them into a single
-Django project template.
+New web-apps should be spawned from Playdoh_ and existing ones should follow the
+spirit of Playdoh_. Playdoh_ collects lessons that several Mozilla Django
+projects have learned and wraps them into a single Django project template.
 
-In the future, much of Playdoh_'s moving parts (Middleware, filters,
-etc) will be moved into a separate library so these features won't be
-lost.
+In the future, much of Playdoh_'s moving parts (Middleware, filters, etc) will
+be moved into a separate library so these features won't be lost.
 
 See :ref:`packaging`.
 
@@ -242,5 +236,5 @@ HTML
 
 .. todo::
 
-   The previous list compiles to weird html where the list is a bunch
-   of separate lists.
+   The previous list compiles to weird html where the list is a bunch of
+   separate lists.

--- a/communications.rst
+++ b/communications.rst
@@ -27,8 +27,8 @@ Two mailing lists are the most important:
   Mozilla. File a ServiceNow request to get subscribed to it and use the list
   for topics that would not be interesting outside the Webdev group at Mozilla.
 
-Additionally, many teams have their own, team-specific mailing lists. Check
-with your manager and have her or him add you.
+Additionally, many teams have their own, team-specific mailing lists. Check with
+your manager and have her or him add you.
 
 .. _`dev-webdev`: https://lists.mozilla.org/listinfo/dev-webdev
 
@@ -37,9 +37,9 @@ with your manager and have her or him add you.
 IRC
 ---
 
-There's a Mozilla IRC server at ``irc.mozilla.org``. The `Mozilla IRC
-server`_ page on the wiki talks about how to connect, how to ask
-questions, and other things.
+There's a Mozilla IRC server at ``irc.mozilla.org``. The `Mozilla IRC server`_
+page on the wiki talks about how to connect, how to ask questions, and other
+things.
 
 We hang out on a bunch of different channels:
 

--- a/css-style.rst
+++ b/css-style.rst
@@ -6,10 +6,10 @@ CSS Style Guide
 Terminology
 -----------
 
-Just so we all know what we're talking about, a CSS *rule*
-comprises one or more *selectors* followed by a *declaration block*
-consisting of one or more *declarations*. A declaration comprises a
-*property* and a *value* (some properties accept multiple values).
+Just so we all know what we're talking about, a CSS *rule* comprises one or more
+*selectors* followed by a *declaration block* consisting of one or more
+*declarations*. A declaration comprises a *property* and a *value* (some
+properties accept multiple values).
 
 A rule in CSS looks like::
 
@@ -45,13 +45,14 @@ General guidelines
 ------------------
 
 Use hex color codes unless using `rgba()` or `hsla()`. Write hex values in
-lowercase and, if possible, the shorthand notation, e.g. ``#ff0`` is better
-than ``#FFFF00``.
+lowercase and, if possible, the shorthand notation, e.g. ``#ff0`` is better than
+``#FFFF00``.
 
-Use single quotation marks for property values that require quotes, such
-as ``content: 'x';`` or ``font-family: 'Open Sans';``.
+Use single quotation marks for property values that require quotes, such as
+``content: 'x';`` or ``font-family: 'Open Sans';``.
 
-Also single-quote attribute values in selectors such as ``input[type='search']``.
+Also single-quote attribute values in selectors such as
+``input[type='search']``.
 
 | Don't use quotation marks in URLs:
 | **No:** ``url('/images/dalek.png')``
@@ -59,9 +60,10 @@ Also single-quote attribute values in selectors such as ``input[type='search']``
 
 .. Note::
 
-    You can single-quote URLs if the file path contains spaces, as that's generally
-    more readable than URL-encoding (`foo%20bar.png`, yuck). But better yet,
-    don't put spaces in file names or URLs, assuming you have control over them.
+    You can single-quote URLs if the file path contains spaces, as that's
+    generally more readable than URL-encoding (`foo%20bar.png`, yuck). But
+    better yet, don't put spaces in file names or URLs, assuming you have
+    control over them.
 
 Use protocol-relative URIs for any external resources, e.g.
 ``url(//fonts.googleapis.com/css?family=Open+Sans);``
@@ -70,22 +72,21 @@ Use protocol-relative URIs for any external resources, e.g.
 
     If your site is secured with https and the external resource is not,
     omitting the protocol from a URI will result in a 404 error, which is
-    perhaps better than a mixed content warning. Then again, it's usually
-    best to avoid referencing external resources in CSS at all.
+    perhaps better than a mixed content warning. Then again, it's usually best
+    to avoid referencing external resources in CSS at all.
 
-If a length value is `0`, do not specify units; ``0px`` and ``0in`` are
-exactly equal because zero is zero.
+If a length value is `0`, do not specify units; ``0px`` and ``0in`` are exactly
+equal because zero is zero.
 
 Omit leading zeroes in decimal units, e.g. ``.75em``, not ``0.75em``.
 
 When using experimental properties with vendor prefixes, always include the
-unprefixed declaration as well, and always last in the list. An exception
-would be a strictly vendor-specific property with no standard implementation,
-like ``-webkit-font-smoothing``.
+unprefixed declaration as well, and always last in the list. An exception would
+be a strictly vendor-specific property with no standard implementation, like
+``-webkit-font-smoothing``.
 
-When declaring gradient backgrounds, you don't need to include the
-`old Webkit syntax`_ unless, for some reason, you need to target old versions
-of Safari.
+When declaring gradient backgrounds, you don't need to include the `old Webkit
+syntax`_ unless, for some reason, you need to target old versions of Safari.
 
 .. _old Webkit syntax: http://www.webkit.org/blog/175/introducing-css-gradients/
 
@@ -104,34 +105,32 @@ Use the least specific selector required to do the job.
 
 Favor classes over IDs.
 
-IDs aren't forbidden, but reserve them for either major blocks (site
-header, main nav, etc) or very specific singletons that are truly unique.
-Hanging styles from ID selectors can lead to specificity wars requiring
-ever more powerful selectors to override previous styling.
+IDs aren't forbidden, but reserve them for either major blocks (site header,
+main nav, etc) or very specific singletons that are truly unique. Hanging styles
+from ID selectors can lead to specificity wars requiring ever more powerful
+selectors to override previous styling.
 
-Avoid qualifying class names with type selectors. E.g. ``.widget`` is
-better than ``div.widget``.
+Avoid qualifying class names with type selectors. E.g. ``.widget`` is better
+than ``div.widget``.
 
-In rare cases it may be necessary to distinguish different elements
-that belong to the same class but require slightly different styling,
-such as ``a.button`` and ``input.button``. Most of the time a class
-or ID alone is sufficient, and decoupling it from a specific element
-makes the name more reusable (yes, an ID can be reusable, just not in
-the same HTML document; ``#main-content`` could be a ``main`` element
-on one page and an ``article`` element on another).
+In rare cases it may be necessary to distinguish different elements that belong
+to the same class but require slightly different styling, such as ``a.button``
+and ``input.button``. Most of the time a class or ID alone is sufficient, and
+decoupling it from a specific element makes the name more reusable (yes, an ID
+can be reusable, just not in the same HTML document; ``#main-content`` could be
+a ``main`` element on one page and an ``article`` element on another).
 
 Avoid adjoining classes unless there's a good reason to do it.
 
-Sometimes different elements share a class but have an additional modifier
-class that extends the meaning and changes the styling. E.g. ``.message.error``
-and ``.message.success``. You could simply take advantage of the cascade order
-and declare the ``.error`` and ``.success`` classes after the ``.message``
-class, but you can't always ensure classes will be kept in the proper cascade
-order (rules get moved around as style sheets are refactored, or they appear
-in different style sheets imported at different points, etc). In those cases
-you might prefer to create a single, more explicit modifier class rather
-than rely on adjoined classes, e.g. ``.message-error`` and
-``.message-success``.
+Sometimes different elements share a class but have an additional modifier class
+that extends the meaning and changes the styling. E.g. ``.message.error`` and
+``.message.success``. You could simply take advantage of the cascade order and
+declare the ``.error`` and ``.success`` classes after the ``.message`` class,
+but you can't always ensure classes will be kept in the proper cascade order
+(rules get moved around as style sheets are refactored, or they appear in
+different style sheets imported at different points, etc). In those cases you
+might prefer to create a single, more explicit modifier class rather than rely
+on adjoined classes, e.g. ``.message-error`` and ``.message-success``.
 
 However, don't try to CLASS ALL THE THINGS by creating a unique class for every
 single element just for an easy style hook, or by creating oodles of generic
@@ -158,10 +157,9 @@ classes on each element in the markup.
         font-size: 16px;
     }
 
-It's usually better to style elements based on their context than to try to
-make every possible style rule free-standing and every element 100% reusable in
-any context on any page. Use descendant selectors judiciously but keep them
-simple.
+It's usually better to style elements based on their context than to try to make
+every possible style rule free-standing and every element 100% reusable in any
+context on any page. Use descendant selectors judiciously but keep them simple.
 
 **Good:** ::
 
@@ -173,13 +171,13 @@ simple.
         font: 16px Georgia, serif;
     }
 
-Avoid ``!important`` in CSS unless absolutely necessary, **which it
-almost never is**.
+Avoid ``!important`` in CSS unless absolutely necessary, **which it almost never
+is**.
 
-Some off-the-shelf frameworks/libraries/plugins include ``!important`` styles
-of their own that you might have to override with another ``!important`` style,
-or they write out inline styling into the DOM that you have to override in a
-style sheet with ``!important``. (One could consider these transgressions to be
+Some off-the-shelf frameworks/libraries/plugins include ``!important`` styles of
+their own that you might have to override with another ``!important`` style, or
+they write out inline styling into the DOM that you have to override in a style
+sheet with ``!important``. (One could consider these transgressions to be
 warning signs of a poorly made framework/library/plugin and you might want to
 seek better options that don't force you to junk up your CSS.)
 
@@ -190,9 +188,9 @@ It's alright to use pixels for ``font-size``.
 
 For many years CSS authors eschewed pixels and favored relative units for font
 sizing because IE 5 and 6 couldn't scale text set in absolute units (like `px`).
-All modern browsers can scale text in any unit (or zoom the entire page) so
-this is no longer a driving concern, unless you're catering to versions of IE
-from the previous century.
+All modern browsers can scale text in any unit (or zoom the entire page) so this
+is no longer a driving concern, unless you're catering to versions of IE from
+the previous century.
 
 There are cases where you'll want to use relative ``font-size`` units like ems
 or percentages. You may have a bit of text that should be sized proportionally
@@ -214,11 +212,11 @@ that may be. E.g. ``line-height: 1.4;`` or in a shorthand `font` property:
 
 .. _unit-less line-height: http://meyerweb.com/eric/thoughts/2006/02/08/unitless-line-heights/
 
-Use "`bulletproof font syntax`_" for webfonts. However, You usually don't
-need to include SVG font files unless your project needs to target older
-versions of WebKit. For modern browsers, TTF + WOFF is sufficient, as well
-as EOT for older versions of IE (which may also be optional, depending
-on your target audience). Example::
+Use "`bulletproof font syntax`_" for webfonts. However, You usually don't need
+to include SVG font files unless your project needs to target older versions of
+WebKit. For modern browsers, TTF + WOFF is sufficient, as well as EOT for older
+versions of IE (which may also be optional, depending on your target audience).
+Example::
 
     @font-face {
         font-family: 'Open Sans';
@@ -236,28 +234,26 @@ on your target audience). Example::
 Formatting CSS
 --------------
 
-When a rule has a group of selectors separated by commas, place each selector
-on its own line.
+When a rule has a group of selectors separated by commas, place each selector on
+its own line.
 
-The opening brace (`{`) of a rule's declaration block should be on the same
-line as the selector (or the same line as the last selector in a group of
-selectors).
+The opening brace (`{`) of a rule's declaration block should be on the same line
+as the selector (or the same line as the last selector in a group of selectors).
 
-Use a single space before the opening brace (`{`) in a rule, after the
-last selector.
+Use a single space before the opening brace (`{`) in a rule, after the last
+selector.
 
 Put each declaration on its own line.
 
 Indent the declaration block one level relative to its selector.
 
-Use a colon (`:`) immediately after the property name, followed by a
-single space, then the value.
+Use a colon (`:`) immediately after the property name, followed by a single
+space, then the value.
 
 Terminate each declaration with a semicolon (`;`), including the last
 declaration in a block.
 
-Put the closing brace (`}`) on its own line, aligned with the rule's
-selector.::
+Put the closing brace (`}`) on its own line, aligned with the rule's selector.::
 
     .selector-1,
     .selector-2 {
@@ -269,11 +265,11 @@ selector.::
         property: value;
     }
 
-When you have a block of related rules, each with one or two declarations,
-you can use a slightly different, single-line format, without any blank
-lines between rules. It makes the block of related rules a bit easier
-to scan. In this case include a single space after the opening brace and
-before the closing brace. Add spaces after the selector to align the values.::
+When you have a block of related rules, each with one or two declarations, you
+can use a slightly different, single-line format, without any blank lines
+between rules. It makes the block of related rules a bit easier to scan. In this
+case include a single space after the opening brace and before the closing
+brace. Add spaces after the selector to align the values.::
 
     .message-success { color: #080; }
     .message-error   { color: #ff0; }
@@ -288,11 +284,11 @@ Or::
         100% { bottom: 30px; }
     }
 
-Long, comma-separated property values -- such as multiple background
-images, gradients, transforms, transitions, or text and box shadows --
-can be arranged across multiple lines (indented one level from their
-property). This improves readability, minimizes horizontal scrolling,
-and produces more useful diffs with meaningful line numbers.::
+Long, comma-separated property values -- such as multiple background images,
+gradients, transforms, transitions, or text and box shadows -- can be arranged
+across multiple lines (indented one level from their property). This improves
+readability, minimizes horizontal scrolling, and produces more useful diffs with
+meaningful line numbers.::
 
     .selector {
         background-image:
@@ -306,8 +302,8 @@ and produces more useful diffs with meaningful line numbers.::
             opacity .1s ease-in;
     }
 
-For vendor prefixed properties, use spaces to align the values, keeping
-the property names left-aligned as usual::
+For vendor prefixed properties, use spaces to align the values, keeping the
+property names left-aligned as usual::
 
     .selector {
         -webkit-box-shadow: 1px 2px 0 #ccc;
@@ -328,10 +324,9 @@ Or, when the value has the prefix::
     }
 
 
-Also notice this implies a specific order for vendor prefixes from
-longest to shortest, mostly just for readability and consistency. It's
-convenient that the unprefixed version, which always appears last, is
-shortest by default.
+Also notice this implies a specific order for vendor prefixes from longest to
+shortest, mostly just for readability and consistency. It's convenient that the
+unprefixed version, which always appears last, is shortest by default.
 
 
 Whitespace
@@ -339,8 +334,8 @@ Whitespace
 
 Use spaces (or soft-tabs) with a four space indent. Never use tabs.
 
-Eliminate trailing whitespace at the end of lines. Blank lines should
-have no spaces.
+Eliminate trailing whitespace at the end of lines. Blank lines should have no
+spaces.
 
 Include one blank line between rules.
 
@@ -360,25 +355,24 @@ Include a single blank line at the end of files.
 Property ordering
 ~~~~~~~~~~~~~~~~~
 
-Order declarations alphabetically by property name (from A to Z),
-with a few exceptions:
+Order declarations alphabetically by property name (from A to Z), with a few
+exceptions:
 
-* Keep vendor prefixed properties together and ordered by length, with
-  the unprefixed property last (see the earlier example).
+* Keep vendor prefixed properties together and ordered by length, with the
+  unprefixed property last (see the earlier example).
 * Keep positioning properties together, namely ``position``, ``top``, ``right``,
   ``bottom``, ``left``, and ``z-index``.
-* You can optionally keep ``width`` and ``height`` together if you're
-  declaring both.
+* You can optionally keep ``width`` and ``height`` together if you're declaring
+  both.
 * You can optionally keep some type-related properties together when that's
   sensible, such as ``font-size``, ``text-transform``, and ``letter-spacing``.
 
-Many developers settle into their own system for ordering declarations
-based on relevance, logical groupings, line length, or just semi-random
-as they're added. Although alphabetical ordering can defy any other
-logical ordering -- adjacent properties may have nothing in common while
-closely related properties can be spread far apart -- at least there's no
-ambiguity about the alphabet and it's easy to enforce the guideline across
-a team.
+Many developers settle into their own system for ordering declarations based on
+relevance, logical groupings, line length, or just semi-random as they're added.
+Although alphabetical ordering can defy any other logical ordering -- adjacent
+properties may have nothing in common while closely related properties can be
+spread far apart -- at least there's no ambiguity about the alphabet and it's
+easy to enforce the guideline across a team.
 
 After all that, it's actually pretty rare for a single rule to hold so many
 declarations that ordering becomes too much of a hassle. When in doubt,
@@ -393,11 +387,11 @@ Naming conventions
 | **Bad:** ``.big-blue-button``, ``.right-column``, ``.small``
 | **Good:** ``.button-submit``, ``.content-sub``, ``.field-note``
 
-Many CSS frameworks, such as Twitter's Bootstrap and Zurb's Foundation, define
-a lot of presentational classes for things like column widths, font sizes,
-and button styles. If you're using such a framework, use those classes
-as mixins in a preprocessed style sheet, rather than littering markup
-with presentational names.
+Many CSS frameworks, such as Twitter's Bootstrap and Zurb's Foundation, define a
+lot of presentational classes for things like column widths, font sizes, and
+button styles. If you're using such a framework, use those classes as mixins in
+a preprocessed style sheet, rather than littering markup with presentational
+names.
 
 **Bad**::
 
@@ -410,9 +404,9 @@ with presentational names.
         .col-md-offset-2;
     }
 
-Names should be as short as possible and as long as necessary.
-Clarity is key. E.g. ``.prime-nav`` is better than ``.primary-navigation``,
-but ``.article-author`` is better than ``.art-auth``.
+Names should be as short as possible and as long as necessary. Clarity is key.
+E.g. ``.prime-nav`` is better than ``.primary-navigation``, but
+``.article-author`` is better than ``.art-auth``.
 
 | Avoid overly abstract names that require a cheat sheet to understand.
 | **Bad:** ``.color12``, ``.r2-c6``, ``.v``
@@ -425,18 +419,18 @@ but ``.article-author`` is better than ``.art-auth``.
 | Separate words with hyphens, not underscores.
 | **Bad:** ``.bad_class_name``, **Best:** ``.best-class-name``
 
-Use US English spellings (sorry, rest of the world). CSS itself follows
-US English so it's inconsistent to mix standard spellings like ``color: #000;``
+Use US English spellings (sorry, rest of the world). CSS itself follows US
+English so it's inconsistent to mix standard spellings like ``color: #000;``
 with classes like ``.colour-picker``.
 
 
 Style sheet organization
 ------------------------
 
-It's hard to standardize on a particular structure for style sheets,
-especially when it comes to preprocessors and other tools that import and
-concatenate separate files. But that doesn't mean we can't try to stick to
-some basic principles:
+It's hard to standardize on a particular structure for style sheets, especially
+when it comes to preprocessors and other tools that import and concatenate
+separate files. But that doesn't mean we can't try to stick to some basic
+principles:
 
 * Group related rules into sections.
 * Give each section a title in a comment.
@@ -445,8 +439,8 @@ some basic principles:
 * Add three blank lines between the last rule in a section and the next
   section's title (clear separation between sections makes scanning easier).
 
-A typical style sheet might be structured from top to bottom like so (only
-an example):
+A typical style sheet might be structured from top to bottom like so (only an
+example):
 
 1. A preamble comment with a table of contents and other info.
 2. *Fonts* (webfonts need to be declared first so you can reference them further
@@ -454,24 +448,25 @@ an example):
 3. *Reset* (global resets should be first so you can override them later).
 4. *Base elements* (no IDs or classes here, just general elements like links,
    headings, lists, forms).
-5. *Base layout* (setting up the general page layout for the entire site, arranging
-   basic blocks like a global header, global footer, main content areas and sidebars).
+5. *Base layout* (setting up the general page layout for the entire site,
+   arranging basic blocks like a global header, global footer, main content
+   areas and sidebars).
 6. *Global components/modules* (general purpose widgets that will be reused like
-   button links, a sidebar menu, pagination, breadcrumbs, footnotes, a search form,
-   error messages).
+   button links, a sidebar menu, pagination, breadcrumbs, footnotes, a search
+   form, error messages).
 7. *Specific page layout* (pages that deviate from the base layout and need more
    more specific styling, like a home page, contact page, gallery page).
 8. *Specific components/modules* (less generic, self-contained widgets that need
    more specific styling like a download button, a contact form, or a carousel).
 
-Many (most) websites end up with a few one-off pages or subsets of pages
-that require more specific styling, rules used only on those pages and nowhere
-else. To avoid dumping everything into a single ever-expanding CSS file, it's
-usually best practice to split it into separate style sheets and combine them
+Many (most) websites end up with a few one-off pages or subsets of pages that
+require more specific styling, rules used only on those pages and nowhere else.
+To avoid dumping everything into a single ever-expanding CSS file, it's usually
+best practice to split it into separate style sheets and combine them
 server-side so each page gets just the rules it needs.
 
-For responsive layouts, collect all the rules for a given medium/viewport
-into a single media query rather than repeat the same media query several times
+For responsive layouts, collect all the rules for a given medium/viewport into a
+single media query rather than repeat the same media query several times
 throughout a style sheet.
 
 
@@ -484,40 +479,41 @@ Write your comments for someone unfamiliar with your site or application. Tell
 them where each set of rules is used and why you did what what you did the way
 you did it.
 
-This is the age of preprocessors and minifiers that strip comments and whitespace
-before it's served to the client anyway so you usually don't need to worry about
-saving bytes in your source files.
+This is the age of preprocessors and minifiers that strip comments and
+whitespace before it's served to the client anyway so you usually don't need to
+worry about saving bytes in your source files.
 
 If you're using a preprocessor that allows it, comment lines with ``//``
 
-Give each section of a style sheet a useful title. You can flag titles with a `@`
-to ease searching. (We like `@` because it's not used much in CSS and can't be
-mistaken for an operator or variable.)
+Give each section of a style sheet a useful title. You can flag titles with a
+`@` to ease searching. (We like `@` because it's not used much in CSS and can't
+be mistaken for an operator or variable.)
 
 Use `KSS <http://warpspire.com/kss/>`_ to document sections, rule sets, and
 individual rules as needed.
 
-Include a "preamble" at the very top of each style sheet with a title, description,
-table of contents, and any other useful information (license, credits, changelog) or
-references (font sizes, color chart, library dependencies).
+Include a "preamble" at the very top of each style sheet with a title,
+description, table of contents, and any other useful information (license,
+credits, changelog) or references (font sizes, color chart, library
+dependencies).
 
 
 Preprocessors
 -------------
 
 All of the above guidelines (those relating to formatting and organization, at
-least) apply equally to vanilla CSS and to style sheets authored for a preprocessor.
-Here are some additional guidelines specific to preprocessors:
+least) apply equally to vanilla CSS and to style sheets authored for a
+preprocessor. Here are some additional guidelines specific to preprocessors:
 
 
 Keep nesting simple
 ~~~~~~~~~~~~~~~~~~~
 
 Nested rules in pre-processed CSS turn into descendant selectors in the
-generated style sheet. The deeper the nesting, the more complex and specific
-the selector will be. Don't nest rules unless necessary for context and
-specificity, and don't nest rules just to group them together (use sectioning
-comments for grouping).
+generated style sheet. The deeper the nesting, the more complex and specific the
+selector will be. Don't nest rules unless necessary for context and specificity,
+and don't nest rules just to group them together (use sectioning comments for
+grouping).
 
 All the declarations for the parent element should come before the nested rules.
 Include a blank line before each nested rule to separate it from the rule or
@@ -552,11 +548,11 @@ declaration above it.
         }
     }
 
-Try to limit nesting to one or two levels. If you find yourself nesting
-rules deeper than three levels, you probably need to reconsider your approach.
+Try to limit nesting to one or two levels. If you find yourself nesting rules
+deeper than three levels, you probably need to reconsider your approach.
 
-If you wouldn't need to use a descendent selector in vanilla CSS, you
-probably don't need to nest it in a pre-processed style sheet.
+If you wouldn't need to use a descendent selector in vanilla CSS, you probably
+don't need to nest it in a pre-processed style sheet.
 
 ::
 
@@ -580,8 +576,8 @@ probably don't need to nest it in a pre-processed style sheet.
         font-size: 18px;
     }
 
-If the parent rule has no declarations, nesting isn't necessary at all.
-If you need the specificity, use an ordinary descendant selector.
+If the parent rule has no declarations, nesting isn't necessary at all. If you
+need the specificity, use an ordinary descendant selector.
 
 ::
 
@@ -611,40 +607,38 @@ If you need the specificity, use an ordinary descendant selector.
 LESS vs. Stylus
 ~~~~~~~~~~~~~~~
 
-Many current and past Mozilla websites use `LESS <http://lesscss.org/>`_
-as a CSS preprocessor. However, LESS appeared to be stagnating for a
-time and some projects moved toward `Stylus <http://learnboost.github.io/stylus/>`_
-as an emerging contender under more active development (and also because
-Stylus has some extra features and shares some traits with Python). LESS has
-since resumed more active development, but in an effort to standardize across
-Mozilla webdev, we're making the call: it's Stylus for us.
+Many current and past Mozilla websites use `LESS <http://lesscss.org/>`_ as a
+CSS preprocessor. However, LESS appeared to be stagnating for a time and some
+projects moved toward `Stylus <http://learnboost.github.io/stylus/>`_ as an
+emerging contender under more active development (and also because Stylus has
+some extra features and shares some traits with Python). LESS has since resumed
+more active development, but in an effort to standardize across Mozilla webdev,
+we're making the call: it's Stylus for us.
 
-New Mozilla webdev projects should use Stylus for CSS preprocessing (or stick with
-vanilla CSS). Sites currently using LESS should work toward converting to Stylus
-as soon as practically feasible
-(`tools can help <https://gist.github.com/cvan/5061790#file-less2stylus-js>`_).
+New Mozilla webdev projects should use Stylus for CSS preprocessing (or stick
+with vanilla CSS). Sites currently using LESS should work toward converting to
+Stylus as soon as practically feasible (`tools can help
+<https://gist.github.com/cvan/5061790#file-less2stylus-js>`_).
 
 
 A Few Words About Stylus
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-On the `Stylus website <http://learnboost.github.io/stylus/>`_, right at the
-top of the home page, the creators crow a lot about how all these required
-CSS syntax bits, like braces and colons and semicolons, are optional in
-Stylus, as if they're a great annoyance that we've all been clamoring to
-abolish for years.
+On the `Stylus website <http://learnboost.github.io/stylus/>`_, right at the top
+of the home page, the creators crow a lot about how all these required CSS
+syntax bits, like braces and colons and semicolons, are optional in Stylus, as
+if they're a great annoyance that we've all been clamoring to abolish for years.
 
 Well, Stylus still generates ordinary CSS in the end, and inserts all those
-optional doodads on your behalf anyway because they're *still required
-in CSS*. Just because Stylus makes them optional doesn't mean we should omit
-them, especially if they make style sheets easier to read. For the sake of
-readability and smoother collaboration, we should try to make CSS look like
-CSS.
+optional doodads on your behalf anyway because they're *still required in CSS*.
+Just because Stylus makes them optional doesn't mean we should omit them,
+especially if they make style sheets easier to read. For the sake of readability
+and smoother collaboration, we should try to make CSS look like CSS.
 
 Format your Stylus-flavored pre-processed files as if you were formatting
-vanilla CSS. Do use mixins, variables, functions, etc. and take advantage
-of all the flexible goodness Stylus offers, but it should still read like
-a CSS document.
+vanilla CSS. Do use mixins, variables, functions, etc. and take advantage of all
+the flexible goodness Stylus offers, but it should still read like a CSS
+document.
 
 * Use CSS syntax (Stylus allows it).
 * Include colons, semi-colons, and braces.
@@ -673,12 +667,12 @@ a CSS document.
 A Note on Sass/SCSS/Compass
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-We don't use Sass because it requires Ruby. While Sass is a fine tool, and
-is especially awesome in combination with Compass, adding Ruby to our dev
-stack is a bridge too far. Sorry Rubyists; we're a Python shop.
+We don't use Sass because it requires Ruby. While Sass is a fine tool, and is
+especially awesome in combination with Compass, adding Ruby to our dev stack is
+a bridge too far. Sorry Rubyists; we're a Python shop.
 
-Even so, all the same formatting and organizational guidelines can apply just
-as well to Sass/SCSS. Live long and prosper.
+Even so, all the same formatting and organizational guidelines can apply just as
+well to Sass/SCSS. Live long and prosper.
 
 
 Validate!
@@ -687,13 +681,13 @@ Validate!
 Validate your CSS with the `W3C's online tool <jigsaw.w3.org/css-validator/>`_
 or equivalent.
 
-Validation tools may report errors or give warnings for vendor prefixes, as
-they should. It's something to be mindful of but it's perfectly fine to use
-prefixed properties if you're doing it right.
+Validation tools may report errors or give warnings for vendor prefixes, as they
+should. It's something to be mindful of but it's perfectly fine to use prefixed
+properties if you're doing it right.
 
-Validation *warnings* are very different from validation *errors*. You should take
-warnings under consideration and address them if needed, but errors are real
-problems that you need to fix.
+Validation *warnings* are very different from validation *errors*. You should
+take warnings under consideration and address them if needed, but errors are
+real problems that you need to fix.
 
 If you're using a preprocessor you'll obviously only be able to validate the
 generated plain CSS, which can make it harder to track down where the errors
@@ -703,13 +697,13 @@ appear in the source files. A well organized style sheet can ease the pain.
 A Note on CSS Lint
 ~~~~~~~~~~~~~~~~~~
 
-`CSS Lint <http://csslint.net/>`_ is a useful tool and we recommend it, but
-take its results with a heavy pinch of salt. Many of Lint's rules are phrased
-like absolute edicts when they're more like soft warnings of things to be mindful
-of (e.g. "Don't use too many floats"). Lint also forbids some things we expressly
+`CSS Lint <http://csslint.net/>`_ is a useful tool and we recommend it, but take
+its results with a heavy pinch of salt. Many of Lint's rules are phrased like
+absolute edicts when they're more like soft warnings of things to be mindful of
+(e.g. "Don't use too many floats"). Lint also forbids some things we expressly
 allow in our own guidelines (e.g. "Don't use ID selectors"). If your file gets a
-slew of warnings from CSS Lint that doesn't mean it's bad, just be able to justify
-your decisions.
+slew of warnings from CSS Lint that doesn't mean it's bad, just be able to
+justify your decisions.
 
 `This shortcut to CSS Lint`_ disables some of the more stringent rules we don't
 necessarily abide.

--- a/data.rst
+++ b/data.rst
@@ -14,17 +14,15 @@ Socorro uses postgres and HBase.
 Production Data
 ---------------
 
-Sometimes having production-like data is necessary for debugging.
-Private data relating to users *must* remain on the Mozilla network.
-Therefore,
-there are two options for
-getting Production or production-like MySQL data.
+Sometimes having production-like data is necessary for debugging. Private data
+relating to users *must* remain on the Mozilla network. Therefore, there are two
+options for getting Production or production-like MySQL data.
 
 Anonymous Data
 ~~~~~~~~~~~~~~
 
-In `~ddash/anonymize` On `webdev1.db.scl3.mozilla.com` on the Mozilla/MPT VPN are
-anonymized dumps of production data for:
+In `~ddash/anonymize` On `webdev1.db.scl3.mozilla.com` on the Mozilla/MPT VPN
+are anonymized dumps of production data for:
 
     * AMO
     * FlightDeck
@@ -38,8 +36,7 @@ Input Data
 
 .. highlight:: bash
 
-You can get a copy of the
-Firefox Input database by using the following script::
+You can get a copy of the Firefox Input database by using the following script::
 
         set -e
         FILE=input_mozilla_com.`date +%Y.%m.%d`.sql.gz
@@ -59,5 +56,5 @@ Be sure to replace ``username`` with your actual LDAP username.
 Webdev Database Cluster
 ~~~~~~~~~~~~~~~~~~~~~~~
 Alternately, many production databases have copies running on
-`webdev1.db.scl3.mozilla.com` and `webdev2.db.scl3.mozilla.com`. You can connect directly to
-these servers.
+`webdev1.db.scl3.mozilla.com` and `webdev2.db.scl3.mozilla.com`. You can connect
+directly to these servers.

--- a/devprocess.rst
+++ b/devprocess.rst
@@ -5,18 +5,17 @@ This document outlines the development process for most projects.
 
 .. Note::
 
-   **Not every project follows this**---notably *Socorro* and *Elmo*.
-   Check with your team lead or manager for clarification and then
-   fork this.
+   **Not every project follows this**---notably *Socorro* and *Elmo*. Check with
+   your team lead or manager for clarification and then fork this.
 
 .. index:: release cycle
 
 Release Cycles
 --------------
 
-Teams work on 1, 2 or 3-week release cycles. Ultimately teams want a
-continuous development process, where code can be developed and placed
-in production immediately.
+Teams work on 1, 2 or 3-week release cycles. Ultimately teams want a continuous
+development process, where code can be developed and placed in production
+immediately.
 
 .. index:: bugs, bugs;cycle, milestones
 
@@ -52,8 +51,8 @@ A Bugs Life
   * After a positive review (``r+``) code will be merged into ``master`` and
     pushed to origin.
   * Most projects avoid ``merge`` commits unless they are necessary.
-  * The bug is marked fixed and a comment to the GitHub_ commit is left in
-    the bug.
+  * The bug is marked fixed and a comment to the GitHub_ commit is left in the
+    bug.
 
 * QA will verify all bugs that have been marked fixed.
 
@@ -66,12 +65,11 @@ A Bugs Life
 QA
 --
 
-QA will verify that bugs are fixed. If you are working on a bug that
-does not need QA verification mark it with ``[qa-]`` in the whiteboard
-status.
+QA will verify that bugs are fixed. If you are working on a bug that does not
+need QA verification mark it with ``[qa-]`` in the whiteboard status.
 
-QA will re-open a bug if they feel it's not complete. They will file
-new bugs if regressions are found within the current milestone.
+QA will re-open a bug if they feel it's not complete. They will file new bugs if
+regressions are found within the current milestone.
 
 
 .. index:: deployment
@@ -79,9 +77,8 @@ new bugs if regressions are found within the current milestone.
 Deployment
 ----------
 
-Deployment varies heavily by product. A typical project will
-branch ``master`` into ``prod`` and tag the release with the
-milestone.
+Deployment varies heavily by product. A typical project will branch ``master``
+into ``prod`` and tag the release with the milestone.
 
 It will then deploy anything in ``prod``.
 

--- a/documentation.rst
+++ b/documentation.rst
@@ -31,8 +31,8 @@ When doing that, follow the `Restructured Text primer`_.
 ReadTheDocs
 -----------
 
-`Read The Docs <http://readthedocs.org/>`_ hosts documentation for
-applications and libraries written in Python.
+`Read The Docs <http://readthedocs.org/>`_ hosts documentation for applications
+and libraries written in Python.
 
 The `Getting Started
 <http://readthedocs.org/docs/read-the-docs/en/latest/getting_started.html>`_

--- a/errors.rst
+++ b/errors.rst
@@ -6,15 +6,15 @@ Error Notification in Production
 ================================
 
 When a traceback occurs in production sites, you need to send it somewhere.
-Normally Django sends emails which can work fine until you get a few
-thousand error emails in a minute.
+Normally Django sends emails which can work fine until you get a few thousand
+error emails in a minute.
 
-To mitigate this, you can use `Arecibo`_ to track your errors. 
-There are currently three servers:
+To mitigate this, you can use `Arecibo`_ to track your errors.  There are
+currently three servers:
 
 https://arecibo-phx.mozilla.org/ (behind LDAP)
    The *preferred* PHX instance.
-   
+
    To use it place the following in your Django settings::
 
       ARECIBO_SERVER_URL = 'http://arecibo1.dmz.phx1.mozilla.com/'
@@ -42,8 +42,8 @@ To send errors from playdoh, see the `playdoh`_ docs.
        curl -I http://arecibo1.dmz.phx1.mozilla.com/
 
 .. note::
-   The PHX data centre server is on a dedicated box, where as SJC is in a VM. Please
-   use the PHX one if possible.
+   The PHX data centre server is on a dedicated box, where as SJC is in a VM.
+   Please use the PHX one if possible.
 
 .. _playdoh: http://playdoh.readthedocs.org/en/latest/userguide/errors.html#arecibo
 .. _Arecibo: http://areciboapp.com

--- a/git.rst
+++ b/git.rst
@@ -6,33 +6,31 @@
 Git and Github
 ==============
 
-Unless you have a good reason you should be using ``git`` and GitHub_
-for version control. One notable exception is many of our projects
-rely on SVN for localizers. We'll be attempting to phase that out.
+Unless you have a good reason you should be using ``git`` and GitHub_ for
+version control. One notable exception is many of our projects rely on SVN for
+localizers. We'll be attempting to phase that out.
 
 Git Resources
 -------------
 
-If you don't know ``git`` or haven't used it in a team, fear not! There are
-lots of awesome sites for git newbies. We recommend:
+If you don't know ``git`` or haven't used it in a team, fear not! There are lots
+of awesome sites for git newbies. We recommend:
 
-* Help.Github_ can help you get started with ``git`` regardless of
-  your operating system. If you haven't used GitHub_ before, it's the
-  perfect crash course. There's also some good info about ``git``
-  itself. You can ignore the "deploy" section, as we have our own
-  deployment process at Mozilla.
-* `Pro Git`_ is probably the best ``git`` resource in existence. It
-  covers pretty much everything you'd want to know about ``git``, so
-  it's quite lengthy, but it's a great read to get to know the basics
-  or to use as a reference. `Pro Git`_ is written by one of the
-  developers at GitHub_.
-* There's a good `list of git resources on StackOverflow`_. It lists
-  tools, tutorials, reference guides, etc. A lot of handy stuff there.
+* Help.Github_ can help you get started with ``git`` regardless of your
+  operating system. If you haven't used GitHub_ before, it's the perfect crash
+  course. There's also some good info about ``git`` itself. You can ignore the
+  "deploy" section, as we have our own deployment process at Mozilla.
+* `Pro Git`_ is probably the best ``git`` resource in existence. It covers
+  pretty much everything you'd want to know about ``git``, so it's quite
+  lengthy, but it's a great read to get to know the basics or to use as a
+  reference. `Pro Git`_ is written by one of the developers at GitHub_.
+* There's a good `list of git resources on StackOverflow`_. It lists tools,
+  tutorials, reference guides, etc. A lot of handy stuff there.
 
-Next time you start a project, use ``git``/GitHub_!  Working on a
-project by yourself is a bit different than working with others, but
-start with some basic ``git`` commands (clone, branch, merge) and some of 
-the more wild stuff (multiple origins, rebasing, etc.) will make more sense.
+Next time you start a project, use ``git``/GitHub_!  Working on a project by
+yourself is a bit different than working with others, but start with some basic
+``git`` commands (clone, branch, merge) and some of the more wild stuff
+(multiple origins, rebasing, etc.) will make more sense.
 
 .. _Help.Github: http://help.github.com/
 .. _`Pro Git`: http://progit.org/book/
@@ -41,18 +39,17 @@ the more wild stuff (multiple origins, rebasing, etc.) will make more sense.
 Git Practices at Mozilla
 ------------------------
 
-* Read about the `git-flow model`_. We work similarly to this at
-  Mozilla, except we use ``master`` as our development branch,
-  ``prod`` for our production branch, and ``bug-$BUG_NUMBER`` as our
-  feature branches. Once you get to know ``git``, understanding how to
-  use/manage branches effectively will allow you to keep different bug
-  fixes and features in their own branches. This is **really
-  awesome**, especially if regressions crop up!
+* Read about the `git-flow model`_. We work similarly to this at Mozilla, except
+  we use ``master`` as our development branch, ``prod`` for our production
+  branch, and ``bug-$BUG_NUMBER`` as our feature branches. Once you get to know
+  ``git``, understanding how to use/manage branches effectively will allow you
+  to keep different bug fixes and features in their own branches. This is
+  **really awesome**, especially if regressions crop up!
 * We use ``git submodule`` for our libraries. This `git submodules explained`_
   article helps you understand how they work.
 * We often use ``git rebase`` to combine and fix commits before merging to
-  mozilla origin repositories. This helps code reviews and keeps
-  commit history clean. GitHub has `a good rebase article`_.
+  mozilla origin repositories. This helps code reviews and keeps commit history
+  clean. GitHub has `a good rebase article`_.
 
 .. _`git-flow model`: http://jeffkreeftmeijer.com/2010/why-arent-you-using-git-flow/
 .. _`git submodules explained`: http://longair.net/blog/2010/06/02/git-submodules-explained/
@@ -61,12 +58,11 @@ Git Practices at Mozilla
 github.com/mozilla
 ------------------
 
-New projects for Mozilla websites should start in the `Mozilla
-account`_.
+New projects for Mozilla websites should start in the `Mozilla account`_.
 
 Contact ``jsocol``, ``wenzel`` or ``peterbe`` to be added to individual projects
-you want to have your way with. They hang out in **#webdev** on IRC,
-which is a fine place to ask for access when you start at Mozilla.
+you want to have your way with. They hang out in **#webdev** on IRC, which is a
+fine place to ask for access when you start at Mozilla.
 
 .. _`Mozilla account`: https://github.com/mozilla
 .. _GitHub: https://github.com/
@@ -80,8 +76,7 @@ GitHub has some service hooks that are helpful to Mozilla projects.
   bug by id, and closes bugs when commit message says 'fix' or 'close'
 * IRC - announces repository pushes in an irc channel
 
-Contact ``davedash`` or ``wenzel`` to get access parameters for the
-hooks.
+Contact ``davedash`` or ``wenzel`` to get access parameters for the hooks.
 
 Working on projects
 -------------------
@@ -93,8 +88,8 @@ In order to work on a project:
 * Merge your commit into ``master`` which should track the
   ``origin/master``
 * ``git push``
-* Place a link to the commit (as it appears in the origin repository)
-  in the relevant bug.
+* Place a link to the commit (as it appears in the origin repository) in the
+  relevant bug.
 
 Commit Messages
 ~~~~~~~~~~~~~~~
@@ -108,12 +103,12 @@ Commit Messages
 Keeping master in sync
 ~~~~~~~~~~~~~~~~~~~~~~
 
-You will want to keep your local ``master`` branch in sync. Typically
-you will rebase your branches with your ``master`` and ultimately you
-will push your ``master`` to ``origin/master``.
+You will want to keep your local ``master`` branch in sync. Typically you will
+rebase your branches with your ``master`` and ultimately you will push your
+``master`` to ``origin/master``.
 
-Let's assume you've defined your ``origin`` remote properly in GitHub.
-E.g. for Zamboni_. ::
+Let's assume you've defined your ``origin`` remote properly in GitHub. E.g. for
+Zamboni_. ::
 
     origin	git@github.com:jbalogh/zamboni.git
 
@@ -135,9 +130,8 @@ Git Tools
 
 **shell**
 
-In order to make life easier we maintain a repository_ of
-``git-tools``. These are shell scripts or python scripts that commit
-all kinds of magic.
+In order to make life easier we maintain a repository_ of ``git-tools``. These
+are shell scripts or python scripts that commit all kinds of magic.
 
 .. _repository: https://github.com/davedash/git-tools
 
@@ -145,14 +139,13 @@ Here's a sampling:
 
 * ``git here`` will tell you the name of your branch, this is an excellent
   building block
-* ``git bugbranch $BUGNUM`` will copy your current branch to an
-  appropriately named bug branch. This uses the :ref:`Bugzilla API
-  <bugzilla-api>`.
-* ``git compare`` with the appropriate ``git.config`` settings will
-  give you a Github_ compare URL for your branch (you'll need to push
-  to Github_ on your own).
-* ``git url`` with the appropriate ``git.config`` settings gives you
-  the last commit's URL on Github_.
+* ``git bugbranch $BUGNUM`` will copy your current branch to an appropriately
+  named bug branch. This uses the :ref:`Bugzilla API <bugzilla-api>`.
+* ``git compare`` with the appropriate ``git.config`` settings will give you a
+  Github_ compare URL for your branch (you'll need to push to Github_ on your
+  own).
+* ``git url`` with the appropriate ``git.config`` settings gives you the last
+  commit's URL on Github_.
 
 Put these in your path and then fork and make your own tools and share.
 
@@ -164,24 +157,22 @@ fugitive.vim_ may very well be the best Git wrapper of all time.
 
 **hub**
 
-hub_ is a git wrapper (or standalone tool) that allows deep integration
-of github into your command-line git workflow. You can easily clone, fork,
-pull-request, and checkout pull-requests locally. Read the page and install
-it now.
+hub_ is a git wrapper (or standalone tool) that allows deep integration of
+github into your command-line git workflow. You can easily clone, fork,
+pull-request, and checkout pull-requests locally. Read the page and install it
+now.
 
 .. _hub: http://hub.github.com/
 
 Oh My Zsh
 ~~~~~~~~~
 
-`Oh My Zsh <https://github.com/robbyrussell/oh-my-zsh>` is an
-excellent collection of zshell scripts that can make your `zsh`
-environment amazing. It includes a collection of plugins, including
-ones for ``git`` and Github_.
+`Oh My Zsh <https://github.com/robbyrussell/oh-my-zsh>` is an excellent
+collection of zshell scripts that can make your `zsh` environment amazing. It
+includes a collection of plugins, including ones for ``git`` and Github_.
 
-Some of these overlap with ``git-tools``. Additionally by using Oh My
-Zsh you can easily display your current branch and it's dirtiness on
-your prompt.
+Some of these overlap with ``git-tools``. Additionally by using Oh My Zsh you
+can easily display your current branch and it's dirtiness on your prompt.
 
 Here is my prompt::
 
@@ -204,9 +195,8 @@ See :ref:`bug-life`
 Looking at someone's code
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Sometimes you need to run someone else's code locally. If they've
-given you a pull request, or a commit hash this is what you need to do
-to see there code::
+Sometimes you need to run someone else's code locally. If they've given you a
+pull request, or a commit hash this is what you need to do to see there code::
 
     git remote add davedash git@github.com:davedash/zamboni.git
     git fetch davedash
@@ -217,8 +207,7 @@ Note:
 * The above assumes that someone else was me.
 * The first line defines a "remote". A remote is simply an alias to a
   repository.
-* The second line fetches all my commit hashes that you don't already
-  have. Usually this is just branches, and commits, but in theory it
-  can be anything.
-* In the third line I can check out your branch. If you just gave me
-  a commit hash I would do ``git co $COMMIT_HASH``.
+* The second line fetches all my commit hashes that you don't already have.
+  Usually this is just branches, and commits, but in theory it can be anything.
+* In the third line I can check out your branch. If you just gave me a commit
+  hash I would do ``git co $COMMIT_HASH``.

--- a/index.rst
+++ b/index.rst
@@ -2,30 +2,25 @@
 Webdev Bootcamp
 ===============
 
-Perhaps you are familiar with Git, Django, jQuery, 
-Python, JS, CSS, HTML, RabbitMQ, Celery and **the DOM**. 
+Perhaps you are familiar with Git, Django, jQuery, Python, JS, CSS, HTML,
+RabbitMQ, Celery and **the DOM**.
 
-Despite all that, web developing at Mozilla can still be
-challenging.  
-The *Webdev Bootcamp* is an attempt to clarify how things 
-are sometimes done.
+Despite all that, web developing at Mozilla can still be challenging. The
+*Webdev Bootcamp* is an attempt to clarify how things are sometimes done.
 
 .. seealso::
-   If you are doing Django development for Mozilla, 
-   much of our Django behavior is encapsulated in 
-   `Playdoh <http://playdoh.readthedocs.org/>`_.
+   If you are doing Django development for Mozilla, much of our Django behavior
+   is encapsulated in `Playdoh <http://playdoh.readthedocs.org/>`_.
 
 .. note::
-   `This documentation is in Github`_,
-   so if you find any mistakes or omissions
+   `This documentation is in Github`_, so if you find any mistakes or omissions
    please fork it and submit a pull request.
 
 .. warning::
-   This document is strictly a guide.  If the documentation told you to 
-   jump off a cliff, `would you <http://xkcd.com/1170/>`_?  Likewise,
-   if you can do something better or if you think what's been
-   documented is not right, challenge it and make life better for your
-   webdev siblings.
+   This document is strictly a guide. If the documentation told you to jump off
+   a cliff, `would you <http://xkcd.com/1170/>`_?  Likewise, if you can do
+   something better or if you think what's been documented is not right,
+   challenge it and make life better for your webdev siblings.
 
 .. toctree::
    :maxdepth: 2

--- a/jenkins.rst
+++ b/jenkins.rst
@@ -7,19 +7,19 @@ Jenkins: Continuous Integration
 ===============================
 
 
-We have a public instance of Jenkins_ (formerly Hudson). For most
-projects it runs their python test suite. Optionally we use it to do
-JS testing as well as any menial tasks that need to be done regularly,
-like packaging. If you break things you will be warned in IRC.
+We have a public instance of Jenkins_ (formerly Hudson). For most projects it
+runs their python test suite. Optionally we use it to do JS testing as well as
+any menial tasks that need to be done regularly, like packaging. If you break
+things you will be warned in IRC.
 
 .. _jenkins: https://ci.mozilla.org/
 
 Adding a new Project
 --------------------
 
-If you've got tests (which you should), and you are deploying to production,
-you might want to add your project to Jenkins_.  This let's the world know just
-how wonderful you are at writing tests.
+If you've got tests (which you should), and you are deploying to production, you
+might want to add your project to Jenkins_. This let's the world know just how
+wonderful you are at writing tests.
 
 Asumming you're working on ``mozilla/awesome_project``, you'll need to:
 

--- a/js-style.rst
+++ b/js-style.rst
@@ -6,14 +6,14 @@ JS Style Guide
 First and Foremost
 ------------------
 
-**ALWAYS** use JSHint_ on your code. 
+**ALWAYS** use JSHint_ on your code.
 
 .. Note::
 
-   There are some exceptions for which JSHint complains about things in
-   node that you can ignore, like how it doesn't know what 'const' is
-   and complains about not knowing what 'require' is. You can add 
-   keywords to ignore to a `.jshintrc` file.
+   There are some exceptions for which JSHint complains about things in node
+   that you can ignore, like how it doesn't know what 'const' is and complains
+   about not knowing what 'require' is. You can add keywords to ignore to a
+   `.jshintrc` file.
 
 .. _JSHint: http://www.jshint.com/
 
@@ -48,7 +48,7 @@ For our projects, always assign var on a newline, not comma separated::
     var a = 1,
         b = 2,
         c = 3;
-    
+
     // Good
     var a = 1;
     var b = 2;
@@ -64,7 +64,7 @@ and the other not so much)::
 
     // Okay on a single line
     var stuff = [1, 2, 3];
-    
+
     // Never on a single line, multiple only
     var longerStuff = [
         'some longer stuff',
@@ -94,8 +94,8 @@ Semi-colons
 
 **Use them.**
 
-Not because ASI is black-magic, or whatever. I'm sure we all understand
-ASI. Just do it for consistency.
+Not because ASI is black-magic, or whatever. I'm sure we all understand ASI.
+Just do it for consistency.
 
 
 Conditionals and Loops
@@ -119,12 +119,12 @@ Space after keyword, and space before curly
 
     // Bad
     if(bad){
-    
+
     }
 
     // Good
     if (something) {
-    
+
     }
 
 
@@ -134,14 +134,13 @@ Functions
 Named Functions
 ~~~~~~~~~~~~~~~
 
-**Always** name functions, even if assigned to another variable or
-property. This improves error stacks when debugging.
+**Always** name functions, even if assigned to another variable or property.
+This improves error stacks when debugging.
 
-No space between name and opening paren. Space between closing paren
-and brace::
+No space between name and opening paren. Space between closing paren and brace::
 
     var method = function doSomething(argOne, argTwo) {
-    
+
     }
 
 
@@ -161,7 +160,7 @@ Only exception is when testing for null and undefined.
 Example::
 
     if (value != null) {
-    
+
     }
 
 
@@ -184,8 +183,8 @@ For node functions, always provide a clear comment in this format::
      */
 
 
-If comments are really long, also do it in the ``/* ... */`` format
-like above. Otherwise make short comments like::
+If comments are really long, also do it in the ``/* ... */`` format like above.
+Otherwise make short comments like::
 
     // This is my short comment and it ends in a period.
 
@@ -207,8 +206,8 @@ If a ternary uses multiple lines, don't use a ternary::
 General Good Practices
 ----------------------
 
-If you see yourself repeating something that can be a constant, refactor
-it as a single constant declaration at the top of the file.
+If you see yourself repeating something that can be a constant, refactor it as a
+single constant declaration at the top of the file.
 
 Cache regex into a constant.
 
@@ -221,9 +220,8 @@ Always check for truthiness::
     if (blah) { ...
 
 
-If code is really long, try to break it up to the next line or 
-refactor (try to keep within the 80-col limit but if you go a bit past
-it's not a big deal). Indent the subsequent lines one indent
-(2-spaces) in.
+If code is really long, try to break it up to the next line or refactor (try to
+keep within the 80-col limit but if you go a bit past it's not a big deal).
+Indent the subsequent lines one indent (2-spaces) in.
 
 If it looks too clever, it probably is, so just make it simple.

--- a/l10n.rst
+++ b/l10n.rst
@@ -39,8 +39,8 @@ Now in your project root::
     svn co https://svn.mozilla.org/projects/l10n-misc/trunk/$MYPROJECTNAME \
     locale
 
-Anytime you make changes using the ``merge`` or ``extract`` commands you'll
-need to commit them back to SVN::
+Anytime you make changes using the ``merge`` or ``extract`` commands you'll need
+to commit them back to SVN::
 
     cd locale/
     svn add *
@@ -61,9 +61,11 @@ Adding new locales (non-django)
 
     See :ref:`playdoh:l10n` in Playdoh for django instructions
 
-To add a new locale to an existing project, go to the Verbatim project admin page, e.g., https://localize.mozilla.org/projects/mdn/admin.html
+To add a new locale to an existing project, go to the Verbatim project admin
+page, e.g., https://localize.mozilla.org/projects/mdn/admin.html
 
-Use the dropdown at the bottom of the list of locales to add the new locale to verbatim
+Use the dropdown at the bottom of the list of locales to add the new locale to
+verbatim
 
 ssh to the verbatim box and add the new locale to svn::
 
@@ -88,7 +90,8 @@ Adding a new text domain (non-django)
 
 Sometimes in a single project you need to use more than one translatable module.
 A text domain is a handle for each module with different .po files. For example,
-MDN uses separate text domains for the MDN website and the `Promote MDN WordPress plugin`_.
+MDN uses separate text domains for the MDN website and the `Promote MDN
+WordPress plugin`_.
 
 You can still use Verbatim to translate these other text domains alongside the
 primary domain.
@@ -114,5 +117,3 @@ Make this better
 This process is merely a suggestion. If you think localization can be improved
 or perhaps automated, by all means... **DO IT!** If your improvement takes off
 update this, so others can benefit.
-
-

--- a/localdev.rst
+++ b/localdev.rst
@@ -1,11 +1,10 @@
 Developing Locally
 ==================
 
-For many sites (AMO, SUMO, Input, etc),
-developing locally is an easy achievement.
+For many sites (AMO, SUMO, Input, etc), developing locally is an easy
+achievement.
 
-Developing locally
-allows you to be able to work anywhere without relying on
+Developing locally allows you to be able to work anywhere without relying on
 network connectivity or being.
 
 .. index::
@@ -17,8 +16,8 @@ Homebrew (Mac OS X)
 -------------------
 
 Most web developers choose a MacBook Pro as their development machine.
-Therefore we recommend Homebrew_.
-Almost all the required development tools can be acquired via ``brew``:
+Therefore we recommend Homebrew_. Almost all the required development tools can
+be acquired via ``brew``:
 
 * git
 * sphinx search
@@ -37,27 +36,27 @@ compile, you can create your own recipes.
 Xcode (Mac OS X)
 ----------------
 
-You need Apple's Xcode to compile packages. If you're on the Mozilla
-network (in the Mountain View office or on OfficeVPN) you can connect to fs2
-(``smb://fs2``) using your LDAP account and find a recent version of Xcode 3
-in the "mac" folder.
+You need Apple's Xcode to compile packages. If you're on the Mozilla network (in
+the Mountain View office or on OfficeVPN) you can connect to fs2 (``smb://fs2``)
+using your LDAP account and find a recent version of Xcode 3 in the "mac"
+folder.
 
 You can also get Xcode from http://developer.apple.com/xcode/, if you have an
-Apple Developer account. There are currently problems using Homebrew with
-Xcode 4, so make sure you get a recent version of Xcode 3 if you're
-downloading it from Apple's site. You can install Xcode 3 and 4 alongside
-each other (in separate folders) if you already use Xcode 4 for other things.
+Apple Developer account. There are currently problems using Homebrew with Xcode
+4, so make sure you get a recent version of Xcode 3 if you're downloading it
+from Apple's site. You can install Xcode 3 and 4 alongside each other (in
+separate folders) if you already use Xcode 4 for other things.
 
-If you're in the Mozilla Mountain View office (or you have VPN access to it
-via Mozilla-MV) you can grab a recent, compatible version of Xcode 3 from
-our ``fs2`` file server by connecting to ``smb://fs2`` as a guest and
-selecting the ``public`` volume. Xcode 3.2 is in the ``mac`` folder.
-See more about :ref:`vpn-info`.
+If you're in the Mozilla Mountain View office (or you have VPN access to it via
+Mozilla-MV) you can grab a recent, compatible version of Xcode 3 from our
+``fs2`` file server by connecting to ``smb://fs2`` as a guest and selecting the
+``public`` volume. Xcode 3.2 is in the ``mac`` folder. See more about
+:ref:`vpn-info`.
 
 *Note*: If you don't have an Apple Developer account, it might be easier to
 simply grab Xcode from the shared volume on ``fs2``. Navigating the Apple
-Developer site, especially if your account is a free account, can be a bit of
-a maze.
+Developer site, especially if your account is a free account, can be a bit of a
+maze.
 
 
 .. _Homebrew: https://github.com/mxcl/homebrew/
@@ -66,10 +65,8 @@ a maze.
 Homework
 --------
 
-Install Homebrew_ and
-install ``git``, ``sphinx``, ``mysql``, ``gettext``, and ``python``.
-You'll need at least these items
-for most projects.
+Install Homebrew_ and install ``git``, ``sphinx``, ``mysql``, ``gettext``, and
+``python``. You'll need at least these items for most projects.
 
 For gettext, you'll need to ``brew link gettext`` so your system uses the GNU
 version of gettext instead of the BSD version Apple provides.

--- a/packaging.rst
+++ b/packaging.rst
@@ -4,10 +4,8 @@
 Packaging and Dependency Management
 ===================================
 
-Python projects can incur
-a number of dependencies.
-``pip`` can be handy, but we've had better luck with distributing a ``vendor``
-library.
+Python projects can incur a number of dependencies. ``pip`` can be handy, but
+we've had better luck with distributing a ``vendor`` library.
 
 For the basics, read `Zamboni packaging`_ as well as :ref:`playdoh:packages`.
 
@@ -17,11 +15,8 @@ For the basics, read `Zamboni packaging`_ as well as :ref:`playdoh:packages`.
 Updating a Library
 ------------------
 
-Let's say we want to update Django to 1.3.
-We already have Django
-setup in our ``requirements/prod.txt``
-as well as a submodule of our vendor
-directory.
+Let's say we want to update Django to 1.3. We already have Django setup in our
+``requirements/prod.txt`` as well as a submodule of our vendor directory.
 
 ``prod.txt``::
 
@@ -49,10 +44,8 @@ Save and quit, puts us back on the command line.::
   $ git commit -m"Bug 1235 Upgrading to Django 1.3"
   $ git push origin master
 
-Now other developers can pick up your changes into their
-`virtualenv`
-and IT can pickup your changes in `vendor` and push out to
-the web heads.
+Now other developers can pick up your changes into their `virtualenv` and IT can
+pickup your changes in `vendor` and push out to the web heads.
 
 Upgrading Libraries
 -------------------
@@ -63,8 +56,8 @@ To keep up-to-date, one should occassionally do::
   git submodule --update --init
   popd
 
-This will refresh the libraries you've installed with their
-latest tagged version.
+This will refresh the libraries you've installed with their latest tagged
+version.
 
 Todo
 ----

--- a/servers.rst
+++ b/servers.rst
@@ -10,10 +10,11 @@ option is available.
 
 **\*.allizom.org**: all our staging servers share this domain.
 
-**webdev1.db.scl3.mozilla.com** is the webdev mysql server. See :ref:`db-cluster`.
+**webdev1.db.scl3.mozilla.com** is the webdev mysql server. See
+:ref:`db-cluster`.
 
-**cm-vpn01** is where our server logs are copied. Note that you need to file
-a bug to get access to this server.
+**cm-vpn01** is where our server logs are copied. Note that you need to file a
+bug to get access to this server.
 
 Served Environments
 -------------------
@@ -23,8 +24,8 @@ There are two or three main environments for our web sites:
 * **dev** (currently "stage" or "preview") which serves the latest `master`.
 * **stage**
 
-  * Currently ``amo-next`` and ``crash-stats.stage`` are
-    our only "stage" environments.
+  * Currently ``amo-next`` and ``crash-stats.stage`` are our only "stage"
+    environments.
   * This is what will go live to production.
 
 * **production**
@@ -35,15 +36,15 @@ VPN
 ---
 
 To get to any Mozilla servers you will need VPN access. There are two VPN
-networks: Mozilla-MV_ (Mountain View office VPN) and Mozilla-MPT_ (for access
-to khan, staging servers, etc.).
+networks: Mozilla-MV_ (Mountain View office VPN) and Mozilla-MPT_ (for access to
+khan, staging servers, etc.).
 
 If you want to use Mozilla's shared network volumes (like ``fs2``) you can
 connect to the Mozilla-MV VPN.
 
-If you need to access khan, database servers, or the cm-vpn01 server, connect
-to Mozilla MPT. You'll need to file a ticket for `access to MPT`_. If you're a
-web dev for Mozilla, **you need this**.
+If you need to access khan, database servers, or the cm-vpn01 server, connect to
+Mozilla MPT. You'll need to file a ticket for `access to MPT`_. If you're a web
+dev for Mozilla, **you need this**.
 
 We recommend Viscosity_ for VPN.
 


### PR DESCRIPTION
Most of the formatting here was already readable, but a number of paragraphs broke at random points ([example](https://github.com/mozilla/webdev-bootcamp/pull/33/files#r6957100)). I went a little overboard and just reformatted everything.

These changes should not affect the generated output. I used `make singlehtml`, screenshots, and [ImageMagick compare](http://www.imagemagick.org/Usage/compare/) to compare the generated content (note _content_ -- this approach does not take things like link destinations into account) and confirmed that the only change was a line number citation at the end of the _Todo_ section, which changed because my reformatting shortened `coding.rst`.
