### PR TITLE
Add a license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,16 @@
+Copyright Mozilla
+
+---
+
+Creative Commons Attribution 4.0 International (CC BY 4.0)
+
+You are free to:
+
+    Share — copy and redistribute the material in any medium or format
+    Adapt — remix, transform, and build upon the material
+
+    for any purpose, even commercially.
+
+The licensor cannot revoke these freedoms as long as you follow the license terms.
+
+For more info see: https://creativecommons.org/licenses/by/4.0/

--- a/README.rst
+++ b/README.rst
@@ -29,3 +29,11 @@ changed.
 
 .. _pip: https://pip.pypa.io/
 .. _virtualenv: https://virtualenv.pypa.io/
+
+Licensing
+---------
+
+Feel free to fork this repo or adapt its work for your own bootcamp. All work
+is licensed under a `Creative Commons Attribution`_license.
+
+.. _license: https://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
@wlach asked on IRC if he could repurpose this bootcamp, to which I replied "of course!" ![screen shot 2014-12-19 at 16 08 52](https://cloud.githubusercontent.com/assets/90871/5511363/7786c5e8-879a-11e4-9572-bdc7d5f14e4a.png)

But I found the question odd! Turns out the license is not mentioned anywhere in the repo itself, or at least not i the top-level or README. The work was already CC-BY-4.0, so I just added a link to the license from the README and a file at the root explaining it's cool to use our work.
