### PR TITLE
Update external links and fix some typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-Mozilla WebDev Bootcamp
+Mozilla Webdev Bootcamp
 =======================
-`View this document at mozweb.readthedocs.org <http://mozweb.readthedocs.org>`_
+`View this document at mozweb.readthedocs.org <https://mozweb.readthedocs.org>`_
 
 A roadmap to success as a web developer contributing to Mozilla. Now with 80%
 more success!
@@ -23,9 +23,9 @@ If you'd like to build the bootcamp locally:
 
 The resulting docs can be located under the ``_build/html`` directory.
 
-You can also run ``make livehtml`` to launch a webserver on
-http://127.0.0.1:8000 that auto-rebuild the documentation when any files are
-changed.
+You can also run ``make livehtml`` to launch a web server on
+http://127.0.0.1:8000 to rebuild the documentation automatically when any
+files are changed.
 
 .. _pip: https://pip.pypa.io/
 .. _virtualenv: https://virtualenv.pypa.io/
@@ -34,6 +34,6 @@ Licensing
 ---------
 
 Feel free to fork this repo or adapt its work for your own bootcamp. All work
-is licensed under a `Creative Commons Attribution`_.
+is licensed under a `Creative Commons Attribution`_ license.
 
 .. _`Creative Commons Attribution`: https://creativecommons.org/licenses/by/4.0/

--- a/conf.py
+++ b/conf.py
@@ -223,5 +223,5 @@ man_pages = [
 ]
 
 intersphinx_mapping = dict(
-    playdoh=('http://playdoh.readthedocs.org/en/latest/', None)
+    playdoh=('https://playdoh.readthedocs.org/en/latest/', None)
     )

--- a/conf.py
+++ b/conf.py
@@ -223,5 +223,5 @@ man_pages = [
 ]
 
 intersphinx_mapping = dict(
-    playdoh=('https://playdoh.readthedocs.org/en/latest/', None)
+    playdoh=('https://playdoh.readthedocs.io/', None)
     )

--- a/guide/accounts.rst
+++ b/guide/accounts.rst
@@ -5,25 +5,25 @@ We use a few websites to manage our code and bugs, and while it is possible to
 get by without signing up for these sites, it's *strongly* recommended that
 you create accounts on these websites.
 
-Github
+GitHub
 ------
 
-Most Webdev projects are hosted on Github_. Github provides hosting for our
-source code, as well as tools we use for collaboration and code review. Github
+Most Webdev projects are hosted on GitHub_. GitHub provides hosting for our
+source code, as well as tools we use for collaboration and code review. GitHub
 is based on git_, a distributed version control system that lets us track the
 changes we make to our code.
 
-Once you've created a Github account, you can check out the `Github help site`_
-for guides on the basics of using git and Github.
+Once you've created a GitHub account, you can check out the `GitHub help site`_
+for guides on the basics of using git and GitHub.
 
 .. seealso::
 
-   `Mozilla on Github <https://github.com/mozilla/>`_
-      Mozilla's organization account on Github.
+   `Mozilla on GitHub <https://github.com/mozilla/>`_
+      Mozilla's organization account on GitHub.
 
-.. _Github: https://github.com/
+.. _GitHub: https://github.com/
 .. _git: https://git-scm.com/
-.. _Github help site: https://help.github.com/
+.. _GitHub help site: https://help.github.com/
 
 Bugzilla
 --------

--- a/guide/accounts.rst
+++ b/guide/accounts.rst
@@ -22,7 +22,7 @@ for guides on the basics of using git and Github.
       Mozilla's organization account on Github.
 
 .. _Github: https://github.com/
-.. _git: http://git-scm.com/
+.. _git: https://git-scm.com/
 .. _Github help site: https://help.github.com/
 
 Bugzilla

--- a/guide/best-practices.rst
+++ b/guide/best-practices.rst
@@ -3,7 +3,7 @@ Best Practices
 
 .. _best-practices-github:
 
-Git and Github
+Git and GitHub
 --------------
 
 - Create a separate pull request for each bug.

--- a/guide/development_process.rst
+++ b/guide/development_process.rst
@@ -43,20 +43,20 @@ The process of fixing a bug involves:
   updating your changes in response to the review.
 - Merging your feature branch back into the main branch used for development.
 
-Git and Github
+Git and GitHub
 ^^^^^^^^^^^^^^
 
-For projects using Git and Github (which is most Webdev projects), the process
+For projects using Git and GitHub (which is most Webdev projects), the process
 can be explained in more detail:
 
-- On Github, ensure you have `forked the repository`_ for your project to your
+- On GitHub, ensure you have `forked the repository`_ for your project to your
   own account and have added it as a `remote`_ to your repository.
 - Identify the main development branch for your project. This is usually the
   ``master`` branch.
 - Make sure the current branch is the development branch and create a new
   branch off of it for your feature.
 - Once your work is committed and ready for review, `push the branch`_ to your
-  fork on Github and `submit a pull request`_.
+  fork on GitHub and `submit a pull request`_.
 - If you know who should review your change, add a comment to your pull request
   with their ``@Username`` in it and ask for a review (often abbreviated as
   ``r?``).
@@ -67,7 +67,7 @@ can be explained in more detail:
       A glossary of specialized terms used within Webdev, including some
       abbreviations used for code review, such as ``r?``, ``r+``, and ``r-``.
 
-   `Github Flow <https://guides.github.com/introduction/flow/>`_
+   `GitHub Flow <https://guides.github.com/introduction/flow/>`_
       A process for branching, reviewing, and merging code that is very similar
       to the process above.
 

--- a/guide/projects.rst
+++ b/guide/projects.rst
@@ -32,7 +32,7 @@ You may also find it useful to find someone who is working on or responsible
 for the project you want to contribute to and asking if they can help you find
 a task to work on and answer any other questions you have. If there's no
 information in the README for a project about who works on it, you can check
-the commit history (available in Github by clicking "# commits" near the top
+the commit history (available in GitHub by clicking "# commits" near the top
 of the page) to find who recently worked on the project, or by asking the
 :doc:`Webdev group <webdev>` who is responsible.
 
@@ -41,7 +41,7 @@ How to contribute
 
 Once you're set up to work on a project, you'll have to find a task to work on
 and get to work! Each project should have some information on where their tasks
-are tracked, whether it be in Bugzilla, Github issues, or some other system.
+are tracked, whether it be in Bugzilla, GitHub issues, or some other system.
 If you're having trouble finding this information, try looking:
 
 - For a ``CONTRIBUTNG`` file in the repository. Many projects use this file

--- a/guide/software.rst
+++ b/guide/software.rst
@@ -21,7 +21,7 @@ If you are running Mac OS X, most of the software mentioned here can be
 installed using the `Homebrew`_ package manager.
 
 .. _VirtualBox: https://www.virtualbox.org/
-.. _Homebrew: http://brew.sh/
+.. _Homebrew: https://brew.sh/
 
 Git
 ---
@@ -45,7 +45,7 @@ same time and merge their changes together at the end.
       A Mac OS X program for interacting with Github as an alternative to using
       git in a terminal. Useful if you are not used to using a terminal yet.
 
-.. _Git: http://git-scm.com/
+.. _Git: https://git-scm.com/
 
 Python
 ------
@@ -75,11 +75,11 @@ as Node applications.
 
 .. seealso::
 
-   `nodejs.org Downloads <http://nodejs.org/download/>`_
+   `nodejs.org Downloads <https://nodejs.org/download/>`_
       The official Node.js download page, which includes installers for Windows
       and Mac OS X.
 
-.. _Node.js: http://nodejs.org/
+.. _Node.js: https://nodejs.org/
 
 Miscellaneous
 -------------------

--- a/guide/software.rst
+++ b/guide/software.rst
@@ -59,7 +59,7 @@ of our servers run the sites on Python 2.
 
 .. seealso::
 
-   `The Hitchhiker's Guide to Python <http://docs.python-guide.org/en/latest/>`_
+   `The Hitchhiker's Guide to Python <http://docs.python-guide.org/>`_
       A useful guide for beginner and expert Python developers. If you need to
       install Python on your computer, this guide will help!
 

--- a/guide/software.rst
+++ b/guide/software.rst
@@ -34,15 +34,15 @@ same time and merge their changes together at the end.
 .. seealso::
 
    `help.github.com <https://help.github.com/>`_
-      A great guide to getting start with Git and Github, which hosts most of
+      A great guide to getting start with Git and GitHub, which hosts most of
       our git repositories.
 
-   `Github for Windows <https://windows.github.com/>`_
-      A Windows program for interacting with Github as an alternative to using
+   `GitHub for Windows <https://windows.github.com/>`_
+      A Windows program for interacting with GitHub as an alternative to using
       git in a terminal. Useful if you are not used to using a terminal yet.
 
-   `Github for Mac <https://mac.github.com/>`_
-      A Mac OS X program for interacting with Github as an alternative to using
+   `GitHub for Mac <https://mac.github.com/>`_
+      A Mac OS X program for interacting with GitHub as an alternative to using
       git in a terminal. Useful if you are not used to using a terminal yet.
 
 .. _Git: https://git-scm.com/

--- a/reference/css-style.rst
+++ b/reference/css-style.rst
@@ -53,7 +53,7 @@ be a strictly vendor-specific property with no standard implementation, like
 When declaring gradient backgrounds, you don't need to include the `old Webkit
 syntax`_ unless, for some reason, you need to target old versions of Safari.
 
-.. _old Webkit syntax: http://www.webkit.org/blog/175/introducing-css-gradients/
+.. _old Webkit syntax: https://www.webkit.org/blog/175/introducing-css-gradients/
 
 Practice progressive enhancement! Include solid fallback colors for old
 browsers that don't support ``rgba()`` or gradients::
@@ -69,7 +69,7 @@ Hiding content
 Consider screen readers when hiding content. Screen readers will not read
 content that is ``display: none;`` or ``visibility: hidden;``. Hiding something
 visually but not from screen readers requires
-`a bit more CSS <http://webaim.org/techniques/css/invisiblecontent/>`_. Be
+`a bit more CSS <https://webaim.org/techniques/css/invisiblecontent/>`_. Be
 conscientious when choosing your hiding technique.
 
 
@@ -182,7 +182,7 @@ that may be. E.g. ``line-height: 1.4;`` or in a shorthand ``font`` property:
 ``font: 14px/1.4 sans-serif;``. Don't use an absolute unit like ``px`` for
 ``line-height``; it creates more problems than it solves.
 
-.. _unit-less line-height: http://meyerweb.com/eric/thoughts/2006/02/08/unitless-line-heights/
+.. _unit-less line-height: https://meyerweb.com/eric/thoughts/2006/02/08/unitless-line-heights/
 
 Use "`bulletproof font syntax`_" for webfonts. You usually don't need to include
 SVG font files unless your project needs to target older versions of WebKit.
@@ -200,7 +200,7 @@ Example::
     }
 
 
-.. _bulletproof font syntax: http://www.fontspring.com/blog/the-new-bulletproof-font-face-syntax
+.. _bulletproof font syntax: https://blog.fontspring.com/2011/02/the-new-bulletproof-font-face-syntax/
 
 
 Formatting CSS
@@ -561,7 +561,7 @@ LESS vs. Stylus
 
 Many current and past Mozilla websites use `LESS <http://lesscss.org/>`_ as a
 CSS preprocessor. However, LESS appeared to be stagnating for a time and some
-projects moved toward `Stylus <http://learnboost.github.io/stylus/>`_ as an
+projects moved toward `Stylus <http://stylus-lang.com/>`_ as an
 emerging contender under more active development (and also because Stylus has
 some extra features and shares some traits with Python). LESS has since resumed
 more active development, but in an effort to standardize across Mozilla webdev,
@@ -577,7 +577,7 @@ forbidden, but prefer Stylus if you have a choice.
 A Few Words About Stylus
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-On the `Stylus website <http://learnboost.github.io/stylus/>`_, right at the top
+On the `Stylus website <http://stylus-lang.com/>`_, right at the top
 of the home page, the creators crow a lot about how all these required CSS
 syntax bits, like braces and colons and semicolons, are optional in Stylus, as
 if they're a great annoyance that we've all been clamoring to abolish for years.
@@ -620,7 +620,7 @@ document.
 A Note on Sass/SCSS/Compass
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Very few (if any?) Mozilla projects use `Sass <http://sass-lang.com>`_ because
+Very few (if any?) Mozilla projects use `Sass <https://sass-lang.com>`_ because
 it requires Ruby. While Sass is a fine tool, and can be awesome in combination
 with Compass, adding Ruby to our dev stack is a bridge too far. Sorry Rubyists;
 we're a Python shop.
@@ -632,7 +632,7 @@ as well to Sass/SCSS. Live long and prosper.
 Validate!
 ---------
 
-Validate your CSS with the `W3C's online tool <jigsaw.w3.org/css-validator/>`_
+Validate your CSS with the `W3C's online tool <https://github.com/w3c/css-validator>`_
 or equivalent.
 
 Validation tools may report errors or give warnings for vendor prefixes, as they

--- a/reference/git_github.rst
+++ b/reference/git_github.rst
@@ -1,8 +1,8 @@
 
-Git and Github
+Git and GitHub
 ==============
 
-This document describes some tips and tricks for using Git and Github.
+This document describes some tips and tricks for using Git and GitHub.
 There are also some best practices for :ref:`best-practices-github`.
 
 Commit Messages
@@ -55,8 +55,8 @@ the pull request as the content. This will cause Bugzilla to link to the pull
 request and allow you to set the review bit on the attachment to track the
 state of the review in Bugzilla.
 
-Owners and the Mozilla Github Organization
+Owners and the Mozilla GitHub Organization
 ------------------------------------------
-See the `Github page on wiki.mozilla.org <https://wiki.mozilla.org/Github>`_
-for information on the Mozilla organization on Github or anything that requires
+See the `GitHub page on wiki.mozilla.org <https://wiki.mozilla.org/Github>`_
+for information on the Mozilla organization on GitHub or anything that requires
 owner access for the organization.

--- a/reference/glossary.rst
+++ b/reference/glossary.rst
@@ -9,8 +9,8 @@ define those terms.
 
    pull request
    PR
-      A term for a request on Github to merge some changes into a codebase.
-      Pull requests are the primary place where code review happens for Github
+      A term for a request on GitHub to merge some changes into a codebase.
+      Pull requests are the primary place where code review happens for GitHub
       projects.
 
    r?

--- a/reference/l10n.rst
+++ b/reference/l10n.rst
@@ -147,11 +147,11 @@ Things to keep in mind
   .. code-block:: jinja
 
      {# WRONG #}
-     {{ _('Check out the new <a href="http://mozilla.org" rel="external">website</a>!') }}
+     {{ _('Check out the new <a href="https://www.mozilla.org/" rel="external">website</a>!') }}
 
      {# RIGHT #}
      {{ _('Check out the new <a {{ link_attrs }}>website</a>!')
-        |fe('href="http://mozilla.org" rel="external"') }}
+        |fe('href="https://www.mozilla.org/" rel="external"') }}
 
 - Languages vary wildly in how they work. Some languages put punctuation at the
   beginning of sentences. Some languages have a different word for 1 item, 3

--- a/reference/python-style.rst
+++ b/reference/python-style.rst
@@ -13,9 +13,9 @@ General Guidelines
 - Check your code against a linting tool. flake8_ is highly recommended for
   this.
 
-.. _PEP8: http://www.python.org/dev/peps/pep-0008/
-.. _flake8: http://flake8.readthedocs.org/en/latest/
-.. _Pocoo: http://www.pocoo.org/internal/styleguide/
+.. _PEP8: https://www.python.org/dev/peps/pep-0008/
+.. _flake8: https://flake8.readthedocs.org/en/latest/
+.. _Pocoo: https://www.pocoo.org/internal/styleguide/
 
 Import Statements
 -----------------

--- a/reference/python-style.rst
+++ b/reference/python-style.rst
@@ -14,7 +14,7 @@ General Guidelines
   this.
 
 .. _PEP8: https://www.python.org/dev/peps/pep-0008/
-.. _flake8: https://flake8.readthedocs.org/en/latest/
+.. _flake8: https://flake8.readthedocs.io/
 .. _Pocoo: https://www.pocoo.org/internal/styleguide/
 
 Import Statements

--- a/reference/security.rst
+++ b/reference/security.rst
@@ -96,8 +96,8 @@ Projects simplifying the use of CSP
 * Node.js/Express: https://github.com/evilpacket/helmet
 
 
-.. _`wide adoption among browsers`: http://caniuse.com/#search=content%20security%20policy
-.. _`Content Security Policy`: http://www.w3.org/TR/CSP/
+.. _`wide adoption among browsers`: https://caniuse.com/#search=content%20security%20policy
+.. _`Content Security Policy`: https://www.w3.org/TR/CSP/
 .. _`CSP 1.1`: https://dvcs.w3.org/hg/content-security-policy/raw-file/tip/csp-specification.dev.html
 .. _`MDN`: https://developer.mozilla.org/en/docs/Security/CSP
 .. _`Security Review Process`: https://wiki.mozilla.org/Security/ReviewProcess

--- a/reference/security.rst
+++ b/reference/security.rst
@@ -99,9 +99,9 @@ Projects simplifying the use of CSP
 .. _`wide adoption among browsers`: https://caniuse.com/#search=content%20security%20policy
 .. _`Content Security Policy`: https://www.w3.org/TR/CSP/
 .. _`CSP 1.1`: https://dvcs.w3.org/hg/content-security-policy/raw-file/tip/csp-specification.dev.html
-.. _`MDN`: https://developer.mozilla.org/en/docs/Security/CSP
+.. _`MDN`: https://developer.mozilla.org/docs/Security/CSP
 .. _`Security Review Process`: https://wiki.mozilla.org/Security/ReviewProcess
 .. _`blog post`: https://blog.mozilla.org/security/2013/12/12/on-the-x-frame-options-security-header/
-.. _`XFO on MDN`: https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options
-.. _`Django`: https://docs.djangoproject.com/en/dev/ref/clickjacking/#
+.. _`XFO on MDN`: https://developer.mozilla.org/docs/HTTP/X-Frame-Options
+.. _`Django`: https://docs.djangoproject.com/en/dev/ref/clickjacking/
 .. _`NodeJS`: https://npmjs.org/package/helmet

--- a/reference/testing.rst
+++ b/reference/testing.rst
@@ -93,7 +93,7 @@ General
   Github.
 - Selenium_ is a tool for automating browsers, often for testing purposes.
 
-.. _Jenkins: http://jenkins-ci.org/
+.. _Jenkins: https://jenkins.io/
 .. _Travis CI: https://travis-ci.org/
 
 Python
@@ -107,25 +107,25 @@ Python
 
 - `factory-boy`_ replaces test fixtures with factories that generate test
   objects easily. It integrates with the Django ORM to generate model instances
-  with a very conveninent syntax.
+  with a very convenient syntax.
 
 - Mock_ is one of the most popular libraries for replacing parts of the system
   you're testing with mock objects and asserting things about their behavior.
 
-.. _nose: http://nose.readthedocs.org/en/latest/
+.. _nose: https://nose.readthedocs.io/en/latest/
 .. _django-nose: https://github.com/django-nose/django-nose
 .. _nose-progressive: https://github.com/erikrose/nose-progressive
-.. _factory-boy: https://factoryboy.readthedocs.org/
+.. _factory-boy: https://factoryboy.readthedocs.io/en/latest/
 .. _Mock: http://www.voidspace.org.uk/python/mock/
 
 Node / JavaScript
 ^^^^^^^^^^^^^^^^^
 
 - Mocha_ is a framework for running tests on node.js and in the browser.
-- Chai_ is an assertion library with many interfaces to accomodate different
+- Chai_ is an assertion library with many interfaces to accommodate different
   testing styles.
 - Karma_ allows you to execute JavaScript code in multiple real browsers.
 
-.. _Mocha: http://visionmedia.github.io/mocha/
+.. _Mocha: https://mochajs.org/
 .. _Chai: http://chaijs.com/
-.. _Karma: http://karma-runner.github.io
+.. _Karma: https://karma-runner.github.io

--- a/reference/testing.rst
+++ b/reference/testing.rst
@@ -112,10 +112,10 @@ Python
 - Mock_ is one of the most popular libraries for replacing parts of the system
   you're testing with mock objects and asserting things about their behavior.
 
-.. _nose: https://nose.readthedocs.io/en/latest/
+.. _nose: https://nose.readthedocs.io/
 .. _django-nose: https://github.com/django-nose/django-nose
 .. _nose-progressive: https://github.com/erikrose/nose-progressive
-.. _factory-boy: https://factoryboy.readthedocs.io/en/latest/
+.. _factory-boy: https://factoryboy.readthedocs.io/
 .. _Mock: http://www.voidspace.org.uk/python/mock/
 
 Node / JavaScript

--- a/reference/testing.rst
+++ b/reference/testing.rst
@@ -90,7 +90,7 @@ General
 - Jenkins_ is a continuous integration server that builds and/or tests software
   projects continuously.
 - `Travis CI`_ is a hosted continuous integration service that integrates with
-  Github.
+  GitHub.
 - Selenium_ is a tool for automating browsers, often for testing purposes.
 
 .. _Jenkins: https://jenkins.io/


### PR DESCRIPTION
This pull request:

- Changes `http` to `https` for websites that use a secure connection. This prevents the user from requesting (and using) an insecure connection before being given a secure one.
- Fixes the w3c URL leading to a relative path instead of an absolute one. I also changed this link to lead to the GitHub repository since the [jigsaw website](https://jigsaw.w3.org/css-validator/) is down for me as of this writing.
- Changes the only occurrence of `WebDev` to `Webdev` for consistency.
- Fixes some other typos (Thanks to [ripgrep](https://github.com/BurntSushi/ripgrep) and Vim's built-in spell check!).