### PR TITLE
Major Update to the Webdev Bootcamp

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,4 +36,4 @@ Licensing
 Feel free to fork this repo or adapt its work for your own bootcamp. All work
 is licensed under a `Creative Commons Attribution`_ license.
 
-.. _`Creative Commons Attribution`: https://creativecommons.org/licenses/by/4.0/
+.. _Creative Commons Attribution: https://creativecommons.org/licenses/by/4.0/

--- a/conf.py
+++ b/conf.py
@@ -96,23 +96,23 @@ todo_include_todos = True
 
 # -- Options for HTML output ---------------------------------------------------
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
+# The theme to use for HTML and HTML Help pages. See the documentation for
 # a list of builtin themes.
 #html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
-# further.  For a list of options available for each theme, see the
+# further. For a list of options available for each theme, see the
 # documentation.
 #html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
-# The name for this set of Sphinx documents.  If None, it defaults to
+# The name for this set of Sphinx documents. If None, it defaults to
 # "<project> v<release> documentation".
 #html_title = None
 
-# A shorter title for the navigation bar.  Default is the same as html_title.
+# A shorter title for the navigation bar. Default is the same as html_title.
 #html_short_title = None
 
 # The name of an image file (relative to this directory) to place at the top
@@ -120,7 +120,7 @@ todo_include_todos = True
 #html_logo = None
 
 # The name of an image file (within the static path) to use as favicon of the
-# docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
+# docs. This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
 #html_favicon = None
 
@@ -163,7 +163,7 @@ todo_include_todos = True
 #html_show_copyright = True
 
 # If true, an OpenSearch description file will be output, and all pages will
-# contain a <link> tag referring to it.  The value of this option must be the
+# contain a <link> tag referring to it. The value of this option must be the
 # base URL from which the finished HTML is served.
 #html_use_opensearch = ''
 

--- a/conf.py
+++ b/conf.py
@@ -223,5 +223,5 @@ man_pages = [
 ]
 
 intersphinx_mapping = dict(
-    playdoh=('https://playdoh.readthedocs.io/', None)
+    playdoh=('https://playdoh.readthedocs.io/en/latest/', None)
     )

--- a/guide/accounts.rst
+++ b/guide/accounts.rst
@@ -10,11 +10,11 @@ GitHub
 
 Most Webdev projects are hosted on GitHub_. GitHub provides hosting for our
 source code, as well as tools we use for collaboration and code review. GitHub
-is based on git_, a distributed version control system that lets us track the
+is based on Git_, a distributed version control system that lets us track the
 changes we make to our code.
 
-Once you've created a GitHub account, you can check out the `GitHub help site`_
-for guides on the basics of using git and GitHub.
+Once you've created a GitHub account, check out the `GitHub help site`_ for
+introductory guides on using Git and GitHub.
 
 .. seealso::
 
@@ -22,7 +22,7 @@ for guides on the basics of using git and GitHub.
       Mozilla's organization account on GitHub.
 
 .. _GitHub: https://github.com/
-.. _git: https://git-scm.com/
+.. _Git: https://git-scm.com/
 .. _GitHub help site: https://help.github.com/
 
 Bugzilla
@@ -39,10 +39,10 @@ a Bugzilla account. An account also allows you to "CC" yourself on bugs that
 you are interested in, so that you receive emails when those bugs are changed.
 
 After you've been using Bugzilla for a while as a community member,
-it's worthwhile applying for expanded permissions. The editbugs
-permission allows you to assign bugs to yourself and resolve them, for
-example. See the `Bugzilla Permissions Page`_ for details. Note that
-new employees get this permission automatically, no need to ask for it.
+it's worthwhile applying for expanded permissions. The editbugs permission,
+for example, allows you to assign bugs to yourself and resolve them. See
+the `Bugzilla Permissions Page`_ for details. Note that new employees
+get this permission automatically; there is no need to ask for it.
 
 .. note:: It's highly recommended to add your IRC nickname to your real name
    within Bugzilla to make it easy for others to auto-complete your name.

--- a/guide/accounts.rst
+++ b/guide/accounts.rst
@@ -52,4 +52,4 @@ get this permission automatically; there is no need to ask for it.
    ``Cave Johnson [:withthelemons]``.
 
 .. _Bugzilla: https://bugzilla.mozilla.org/
-.. _`Bugzilla Permissions Page`: https://bugzilla.mozilla.org/page.cgi?id=get_permissions.html
+.. _Bugzilla Permissions Page: https://bugzilla.mozilla.org/page.cgi?id=get_permissions.html

--- a/guide/best-practices.rst
+++ b/guide/best-practices.rst
@@ -7,10 +7,17 @@ Git and GitHub
 --------------
 
 - Create a separate pull request for each bug.
-- If you have multiple commits in one pull request, squash them into one. For complex patches, having multiple commits might make the review easier.
-- If you are working with multiple bugs at a time, make sure you create a separate branches for each bug.
-- If you need to make changes to the commit, perhaps after feedback, amend the original commit and comment in the pull request what you've changed.  Don't create a new pull request or commit.
-- Include the bug number in your commit & pull request title. If possible follow this style -`Some text description (bug XXXXXXX)`.
-- Don't work on an assigned bug. If you see the bug assignee hasn’t responded for a while (two weeks), then ask for permission if you can work on that bug.
-- For frontend pull requests, attach screenshots if relevant.
+- If you have multiple commits in one pull request, squash them into one. For
+  complex patches, having multiple commits may make the review easier.
+- If you are working with multiple bugs at a time, make sure you create a
+  separate branches for each bug.
+- If you need to make changes to the commit, perhaps after feedback, amend the
+  original commit and comment in the pull request what you've changed. Don't
+  create a new pull request or commit.
+- Include the bug number in your commit & pull request title. Exactly how
+  depends on which repository you contribute to, but you can always follow this
+  style: ``Description of the commit (bug XXXXXXX)``.
+- Don't work on an assigned bug. If you see the bug assignee hasn't responded
+  for a while (two weeks), then ask for permission if you can work on that bug.
+- For front-end pull requests, attach screenshots if relevant.
 - Put a link to the PR in the bug as a comment.

--- a/guide/development_process.rst
+++ b/guide/development_process.rst
@@ -3,7 +3,7 @@ Development Process
 
 While the details vary, there is a general framework for the development
 process at Mozilla which describes how a change goes from an idea in someone's
-head to deployed code on a production webserver. This document attempts to
+head to deployed code on a production web server. This document attempts to
 describe that process.
 
 Filing a Bug
@@ -26,9 +26,8 @@ kanban board.
 Working on the Bug
 ------------------
 
-Either someone will voluntarily take a bug, or, in the case of projects with
-assigned developers actively working on them, it will be assigned to a
-developer.
+Either someone will voluntarily take a bug, or it will be assigned to a
+developer actively working on the project.
 
 The process of fixing a bug involves:
 
@@ -46,11 +45,13 @@ The process of fixing a bug involves:
 Git and GitHub
 ^^^^^^^^^^^^^^
 
-For projects using Git and GitHub (which is most Webdev projects), the process
+For projects using Git and GitHub (i.e. most Webdev projects), the process
 can be explained in more detail:
 
-- On GitHub, ensure you have `forked the repository`_ for your project to your
-  own account and have added it as a `remote`_ to your repository.
+- On GitHub, ensure that you have `forked the upstream repository`_ for the
+  project to your own account. If you plan to regularly contribute to this
+  repository, you should add the upstream repository as a `remote`_ to your
+  repository so that you can fetch the latest changes from it.
 - Identify the main development branch for your project. This is usually the
   ``master`` branch.
 - Make sure the current branch is the development branch and create a new
@@ -58,7 +59,7 @@ can be explained in more detail:
 - Once your work is committed and ready for review, `push the branch`_ to your
   fork on GitHub and `submit a pull request`_.
 - If you know who should review your change, add a comment to your pull request
-  with their ``@Username`` in it and ask for a review (often abbreviated as
+  with their ``@username`` in it and ask for a review (often abbreviated as
   ``r?``).
 
 .. seealso::
@@ -71,7 +72,7 @@ can be explained in more detail:
       A process for branching, reviewing, and merging code that is very similar
       to the process above.
 
-.. _forked the repository: https://help.github.com/articles/fork-a-repo
+.. _forked the upstream repository: https://help.github.com/articles/fork-a-repo
 .. _remote: https://help.github.com/articles/about-remote-repositories
 .. _push the branch: https://help.github.com/articles/pushing-to-a-remote
 .. _submit a pull request: https://help.github.com/articles/using-pull-requests

--- a/guide/index.rst
+++ b/guide/index.rst
@@ -8,7 +8,7 @@ Our goal here is to get you up and running for contributing as a web developer.
 This guide attempts to be generic enough to be useful to any webdev project,
 but some details (especially around software you need installed) may vary among
 projects. Any project you're contributing to should have documentation that
-explains these details in, uh, detail.
+explains these details in, well, detail!
 
 Let's get started!
 

--- a/guide/projects.rst
+++ b/guide/projects.rst
@@ -15,7 +15,7 @@ projects to contribute to:
   someone may reply with a recommendation.
 
 .. _GetInvolved: https://wiki.mozilla.org/Webdev/GetInvolved
-.. _`dev-webdev@lists.mozilla.org mailing list`: https://lists.mozilla.org/listinfo/dev-webdev
+.. _dev-webdev@lists.mozilla.org mailing list: https://lists.mozilla.org/listinfo/dev-webdev
 
 Getting set up
 --------------

--- a/guide/projects.rst
+++ b/guide/projects.rst
@@ -31,9 +31,9 @@ Find a mentor
 You may also find it useful to find someone who is working on or responsible
 for the project you want to contribute to and asking if they can help you find
 a task to work on and answer any other questions you have. If there's no
-information in the README for a project about who works on it, you can check
-the commit history (available in GitHub by clicking "# commits" near the top
-of the page) to find who recently worked on the project, or by asking the
+information about who works on the project in the README, you can check
+the commit history (available in GitHub by clicking ``# commits`` near the top
+of the page) to find out who recently worked on the project, or by asking the
 :doc:`Webdev group <webdev>` who is responsible.
 
 How to contribute

--- a/guide/software.rst
+++ b/guide/software.rst
@@ -5,21 +5,22 @@ The software you'll need to download and install on your computer in order to
 contribute varies between projects; please refer to the documentation for the
 project you want to contribute to for details.
 
-The following information is a generic description of software or tools that
-you'll most likely need regardless of the project you work on.
+Below is a list of some of the software you'll most likely need regardless of
+the project you work on.
 
-Operating Systems: Windows, Linux, or OS X?
--------------------------------------------
+Operating Systems: Windows, GNU/Linux, or macOS?
+------------------------------------------------
 
-Most of our sites are developed on Mac OS X or Linux, and deployed on servers
-running Linux. If you are a Windows user, you may want to use a program like
-`VirtualBox`_ to create a virtual machine running a Linux-based operating
-system. The rest of this guide assumes you are using an OS X or Linux-based
-operating system.
+Most of our sites are developed on macOS or `GNU/Linux`_, and deployed to
+servers running GNU/Linux. If you are a Windows user, you may want to use a
+program like `VirtualBox`_ to create a virtual machine running a Linux-based
+operating system. The rest of this guide assumes you are using macOS or any
+Linux-based operating system.
 
-If you are running Mac OS X, most of the software mentioned here can be
+If you are running macOS, most of the software mentioned here can be
 installed using the `Homebrew`_ package manager.
 
+.. _GNU/Linux: https://www.gnu.org/
 .. _VirtualBox: https://www.virtualbox.org/
 .. _Homebrew: https://brew.sh/
 
@@ -35,15 +36,12 @@ same time and merge their changes together at the end.
 
    `help.github.com <https://help.github.com/>`_
       A great guide to getting start with Git and GitHub, which hosts most of
-      our git repositories.
+      our Git repositories.
 
-   `GitHub for Windows <https://windows.github.com/>`_
-      A Windows program for interacting with GitHub as an alternative to using
-      git in a terminal. Useful if you are not used to using a terminal yet.
-
-   `GitHub for Mac <https://mac.github.com/>`_
-      A Mac OS X program for interacting with GitHub as an alternative to using
-      git in a terminal. Useful if you are not used to using a terminal yet.
+   `GitHub Desktop <https://desktop.github.com/>`_
+      A graphical user interface for interacting with GitHub repositories.
+      GitHub Desktop works on Windows and macOS and is useful if you're not
+      used to working with Git in the terminal yet.
 
 .. _Git: https://git-scm.com/
 
@@ -51,7 +49,7 @@ Python
 ------
 
 Python_ is a programming language that many of our websites use for their
-backend code. Most of our Python-based sites are implemented using Django_,
+back-end code. Most of our Python-based sites are implemented using Django_,
 a Python-based framework for making websites.
 
 Most of our Python-based sites are developed to run under Python 2, and most
@@ -77,7 +75,8 @@ as Node applications.
 
    `nodejs.org Downloads <https://nodejs.org/download/>`_
       The official Node.js download page, which includes installers for Windows
-      and Mac OS X.
+      and macOS. If you use a variant of GNU/Linux, it's best to install
+      Node.js with your package manager.
 
 .. _Node.js: https://nodejs.org/
 

--- a/guide/webdev.rst
+++ b/guide/webdev.rst
@@ -1,13 +1,14 @@
 The Mozilla Webdev Group
 ========================
 
-Webdev is an informal group of people across the Mozilla project that are
-interested in or work in web development. Webdev isn't linked to a specific
-team and welcomes everyone who wants to be a part of it to join.
+The Mozilla Webdev Group is an informal group of people across the Mozilla
+project that are interested in or work in web development. The group isn't
+linked to a specific team and welcomes everyone who wants to be a part of
+it to join.
 
-As a new contributor, the primary use of the Webdev group will be to help
-answer questions you have or to help you find interesting projects to work on.
-Later on, you can start attending some of our online meetings to meet the rest
+As a new contributor, you'll primarily be using the Webdev group to help
+answer questions you have or to find interesting projects to work on. Later
+on, you can start attending some of our online meetings to meet the rest
 of the group and keep up to date with what everyone else is up to.
 
 How to Talk to Us
@@ -33,5 +34,5 @@ finding your way around.
 
 If you're a new employee, your mentor may be your manager, or it may be a
 coworker. If you're a volunteer, ask someone who works on the project you want
-to contribute to, and if they cannot mentor you themselves, they should be able
+to contribute to. If they cannot mentor you themselves, they should be able
 to direct you to someone who can.

--- a/index.rst
+++ b/index.rst
@@ -6,7 +6,7 @@ development is done at Mozilla.
 
 If you're a new contributor / new employee, you can start out by reading the
 :doc:`guide/index`. If you're already a Webdev contributor, you can find
-generally-useful info, such as style guides, in the :doc:`reference/index`.
+generally-useful information, such as style guides, in the :doc:`reference/index`.
 
 .. toctree::
    :maxdepth: 2

--- a/reference/css-style.rst
+++ b/reference/css-style.rst
@@ -11,7 +11,7 @@ Just so we all know what we're talking about, a CSS *rule* comprises one or more
 *declarations*. A declaration comprises a *property* and a *value* (some
 properties accept multiple values).
 
-A rule in CSS looks like::
+A rule in CSS looks like this::
 
     selector {
         property: value;
@@ -40,8 +40,8 @@ The basics (tl;dr)
 General guidelines
 ------------------
 
-If a length value is ``0``, do not specify units; ``0px`` and ``0in`` are exactly
-equal because zero is zero.
+If a length value is ``0``, do not specify units; ``0px`` and ``0in`` are both
+equal to zero.
 
 Omit leading zeroes in decimal units, e.g. ``.75em``, not ``0.75em``.
 
@@ -125,9 +125,10 @@ classes on each element in the markup.
         font-size: 16px;
     }
 
-It's usually better to style elements based on their context than to try to make
-every possible style rule free-standing and every element 100% reusable in any
-context on any page. Use descendant selectors judiciously but keep them simple.
+It's usually better to style elements based on their context instead of trying
+to make every possible style rule free-standing and every element 100% reusable
+in any context on any page. Use descendant selectors as needed, but keep them
+simple.
 
 **Good:** ::
 
@@ -139,7 +140,10 @@ context on any page. Use descendant selectors judiciously but keep them simple.
         font: 16px Georgia, serif;
     }
 
-Avoid ``!important`` in CSS unless absolutely necessary, **which it almost
+The "!important" declaration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Avoid using ``!important`` unless absolutely necessary. Hint: **it almost
 never is**.
 
 Some off-the-shelf frameworks/libraries/plugins include ``!important`` styles of
@@ -147,7 +151,7 @@ their own that you might have to override with another ``!important`` style, or
 they write out inline styling into the DOM that you have to override in a style
 sheet with ``!important``. (One could consider these transgressions to be
 warning signs of a poorly made framework/library/plugin and you might want to
-seek better options that don't force you to junk up your CSS.)
+seek better options that don't force you to pollute your CSS.)
 
 Fonts and typography
 ~~~~~~~~~~~~~~~~~~~~
@@ -160,7 +164,7 @@ All modern browsers can scale text in any unit (or zoom the entire page) so this
 is no longer a driving concern, unless you're catering to versions of IE from
 the previous century.
 
-There are times when it's better to use relative ``font-size`` units like `em`s
+There are times when it's better to use relative ``font-size`` units like ``em``
 or percentages. You may have a bit of text that should be sized proportionally
 to a parent element whose font size is unknown. Some responsive designs call
 for globally resizing text in different layouts (e.g. globally bigger text for
@@ -168,17 +172,16 @@ mobile), in which case it's simpler to change a single base size on a parent
 than to re-declare the absolute ``font-size`` of each element.
 
 Just remember that relative font sizes inherit and cascade so you can end up
-with magic numbers like ``.6875em``. The ``rem`` unit (root em) can avoid the
+with magic numbers like ``.6875em``. The ``rem`` unit (root em) can avoid these
 cascade problems, but older browsers don't support rems and IE9 and 10 don't
-support them in shorthand ``font`` declarations (fixed in IE11). It's always
-something.
+support them in shorthand ``font`` declarations (fixed in IE11).
 
-If you use ``rem``s for font sizing, include a ``px`` or other fallback
+If you use ``rem`` units for font sizing, include a ``px`` or other fallback
 for older browsers.
 
 Use `unit-less line-height`_. It doesn't inherit a percentage value of its
 parent element, but instead is based on a multiplier of the font-size, whatever
-that may be. E.g. ``line-height: 1.4;`` or in a shorthand ``font`` property:
+that may be, e.g. ``line-height: 1.4;``, or with the shorthand ``font`` property
 ``font: 14px/1.4 sans-serif;``. Don't use an absolute unit like ``px`` for
 ``line-height``; it creates more problems than it solves.
 
@@ -206,27 +209,25 @@ Example::
 Formatting CSS
 --------------
 
-When a rule has a group of selectors separated by commas, place each selector
-on its own line.
+In general, when you're writing CSS, you should follow the following rules:
 
-The opening brace (``{``) of a rule's declaration block should be on the same
-line as the selector (or the same line as the last selector in a group of
-selectors).
+* When a rule has a group of selectors separated by commas, place each selector
+  on its own line.
+* The opening brace (``{``) of a rule's declaration block should be on the same
+  line as the selector (or the same line as the last selector in a group of
+  selectors).
+* Use a single space before the opening brace (``{``) in a rule, after the last
+  selector.
+* Put each declaration on its own line.
+* Indent the declaration block one level relative to its selector.
+* Use a colon (``:``) immediately after the property name, followed by a single
+  space, then the value.
+* Terminate each declaration with a semicolon (``;``), including the last
+  declaration in a block.
+* Put the closing brace (``}``) on its own line, aligned with the rule's
+  selector.
 
-Use a single space before the opening brace (``{``) in a rule, after the last
-selector.
-
-Put each declaration on its own line.
-
-Indent the declaration block one level relative to its selector.
-
-Use a colon (``:``) immediately after the property name, followed by a single
-space, then the value.
-
-Terminate each declaration with a semicolon (``;``), including the last
-declaration in a block.
-
-Put the closing brace (``}``) on its own line, aligned with the rule's selector.::
+Here's an example::
 
     .selector-1,
     .selector-2 {
@@ -239,16 +240,16 @@ Put the closing brace (``}``) on its own line, aligned with the rule's selector.
     }
 
 When you have a block of related rules, each with one or two declarations,
-you can use a single-line format without any blank lines between rules. It
-makes the block of related rules a bit easier to scan. In this case include
+you can use a single-line format without any blank lines between rules. This
+makes the block of related rules a bit easier to scan. When doing so, include
 a single space after the opening brace and before the closing brace. Add
-spaces after the selector to align the values.::
+spaces after the selector to align the values, like so::
 
     .message-success { color: #080; }
     .message-error   { color: #ff0; }
     .message-notice  { color: #00f; }
 
-Or::
+Here's another example::
 
     @keyframes bounce {
         0%   { bottom: 300px; }
@@ -260,12 +261,13 @@ Or::
 When possible, limit line lengths to 80 characters. This improves readability,
 minimizes horizontal scrolling, makes it possible to view files side by side,
 and produces more useful diffs with meaningful line numbers. There will be
-exceptions such as long URLs or gradient syntax but most rules in CSS should
-fit well within 80 characters even with indentation.
+exceptions such as long URLs or gradient syntax but most CSS rules should fit
+well within 80 characters even with indentation.
 
-Long, comma-separated property values -- such as multiple background images,
-gradients, transforms, transitions, webfonts, or text and box shadows -- can
-be arranged across multiple lines (indented one level from their property).::
+Long, comma-separated property values---such as multiple background images,
+gradients, transforms, transitions, webfonts, or text and box shadows---can
+be arranged across multiple lines (indented one level from their property),
+as seen below::
 
     .selector {
         background-image:
@@ -301,9 +303,9 @@ Or, when the value has the prefix::
     }
 
 
-Also notice this implies a specific order for vendor prefixes from longest to
+Note that this implies a specific order for vendor prefixes from longest to
 shortest, mostly just for readability and consistency. It's convenient that the
-unprefixed version, which always appears last, is shortest by default.
+unprefixed version, which always appears last, is the shortest by default.
 
 
 Whitespace
@@ -336,24 +338,25 @@ exceptions:
 
 Many developers settle into their own system for ordering declarations based on
 relevance, logical groupings, line length, or just semi-random as they're added.
-Although alphabetical ordering can defy any other logical ordering -- adjacent
+Although alphabetical ordering can defy any other logical ordering, adjacent
 properties may have nothing in common while closely related properties can be
-spread far apart -- at least there's no ambiguity about the alphabet and it's
-easy to enforce the guideline across a team.
+spread far apart. There's no ambiguity about the alphabet and it's easy to
+enforce this guideline across a team.
 
-After all that, it's actually pretty rare for a single rule to hold so many
-declarations that ordering becomes too much of a hassle. When in doubt,
-alphabetize.
+It's pretty rare for a single rule to hold so many declarations that ordering
+becomes too much of a hassle. When in doubt, alphabetize.
 
 
 Naming conventions
 ------------------
 
 Names should be semantically meaningful, descriptive of the element's content,
-purpose, or function, not its presentation.
+purpose, or function, *not* its presentation.
 
 | **Bad:** ``.big-blue-button``, ``.right-column``, ``.small``
+|
 | **Good:** ``.button-submit``, ``.content-sub``, ``.field-note``
+|
 
 Many CSS frameworks, such as Twitter's Bootstrap and Zurb's Foundation, define
 a lot of presentational classes for things like column widths, font sizes,
@@ -375,33 +378,36 @@ with presentational names.
 .. Note::
 
     For very large and complex sites, excessively repeating common declarations
-    can lead to a lot of redundancy and CSS bloat. In those cases you can get
+    can lead to a lot of redundancy and CSS bloat. In these cases, you can get
     better performance with some presentational classes if it leads to a
-    significantly lighter style sheet. E.g. it can speed up a site considerably
-    to specify column widths with a class in a few dozen HTML templates than to
-    repeat the same width, float, and margin declarations a thousand times in
-    CSS. We don't have many sites operating on the kind of scale that warrants
-    that approach, but there are always exceptions.
+    significantly lighter style sheet. For example, it can speed up a site
+    considerably to specify column widths with a class in a few dozen HTML
+    templates than to repeat the same width, float, and margin declarations
+    a thousand times in CSS. We don't have many sites operating on the kind of
+    scale that warrants such an approach, but there are always exceptions.
 
-Names should be as short as possible and as long as necessary.
-Clarity is key. E.g. ``.prime-nav`` is better than ``.primary-navigation``,
-but ``.article-author`` is better than ``.art-auth``.
+Names should be as short as possible and as long as necessary. ``.prime-nav``
+is better than ``.primary-navigation``, but ``.article-author`` is better
+than ``.art-auth``. Clarity is key.
 
 Avoid overly abstract names that require a cheat sheet to understand.
 
 | **Bad:** ``.color12``, ``.r2-c6``, ``.v``
+|
 
 Names should be all lower case, no camelcase.
 
 | **Bad:** ``.badClassName``, **Better:** ``.betterclassname``
+|
 
 Separate words with hyphens, not underscores.
 
 | **Bad:** ``.bad_class_name``, **Best:** ``.best-class-name``
+|
 
-Use US English spellings (sorry, rest of the world). CSS itself follows US
-English so it's inconsistent to mix standard spellings like ``color: #000;``
-with classes like ``.colour-picker``.
+Always use the American English spellings. It's inconsistent to mix standard
+spellings like ``color: #000;`` with classes like ``.colour-picker``. CSS
+itself follows American English.
 
 
 Style sheet organization
@@ -409,8 +415,8 @@ Style sheet organization
 
 It's hard to standardize on a particular structure for style sheets, especially
 when it comes to preprocessors and other tools that import and concatenate
-separate files. But that doesn't mean we can't try to stick to some basic
-principles:
+separate files. But that doesn't mean we can't try to at least stick to some
+basic principles:
 
 * Group related rules into sections.
 * Give each section a title in a comment.
@@ -422,7 +428,7 @@ principles:
 A typical style sheet might be structured from top to bottom like so (only an
 example):
 
-1. A preamble comment with a table of contents and other info.
+1. A preamble comment with a table of contents and other information.
 2. *Fonts* (webfonts need to be declared first so you can reference them further
    down the cascade).
 3. *Reset* (global resets should be first so you can override them later).
@@ -439,15 +445,16 @@ example):
 8. *Specific components/modules* (less generic, self-contained widgets that need
    more specific styling like a download button, a contact form, or a carousel).
 
-Many (most) websites end up with a few one-off pages or subsets of pages that
-require more specific styling, rules used only on those pages and nowhere else.
-To avoid dumping everything into a single ever-expanding CSS file, it's usually
-best practice to split it into separate style sheets and combine them
-server-side so each page gets just the rules it needs.
+Many (if not most) websites end up with a few one-off pages or subsets of pages
+that require more specific styling. The CSS rules used to style these pages are
+used only on those pages and nowhere else. To avoid dumping everything into a
+single ever-expanding CSS file, it's necessary to split up page-specific rules
+into separate style sheets and combine them server-side so each page gets just
+the rules it needs.
 
 For responsive layouts, collect all the rules for a given medium/viewport into a
-single media query rather than repeat the same media query several times
-throughout a style sheet.
+single media query. Don't repeat the same media query several times throughout
+the style sheet.
 
 
 Preprocessors
@@ -556,30 +563,36 @@ need the specificity, use an ordinary descendant selector.
     }
 
 
-LESS vs. Stylus
-~~~~~~~~~~~~~~~
+Sass vs. Less vs. Stylus
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-Many current and past Mozilla websites use `LESS <http://lesscss.org/>`_ as a
-CSS preprocessor. However, LESS appeared to be stagnating for a time and some
+Many current and past Mozilla websites use `Less <http://lesscss.org/>`_ as a
+CSS preprocessor. However, Less appeared to be stagnating for a time and some
 projects moved toward `Stylus <http://stylus-lang.com/>`_ as an
 emerging contender under more active development (and also because Stylus has
-some extra features and shares some traits with Python). LESS has since resumed
-more active development, but in an effort to standardize across Mozilla webdev,
+some extra features and shares some traits with Python). Less has since resumed
+more active development, but in an effort to standardize across Mozilla Webdev,
 we're making the call: it's Stylus for us.
 
-New Mozilla webdev projects should use Stylus for CSS preprocessing (or stick
-with vanilla CSS). Sites currently using LESS should work toward converting to
+New Mozilla Webdev projects should use Stylus for CSS preprocessing (or stick
+with vanilla CSS). Sites currently using Less should work toward converting to
 Stylus as soon as practically feasible (`tools can help
-<https://gist.github.com/cvan/5061790#file-less2stylus-js>`_). LESS isn't
+<https://gist.github.com/cvan/5061790#file-less2stylus-js>`_). Less isn't
 forbidden, but prefer Stylus if you have a choice.
+
+More recently, some projects such as the `new front-end to Firefox Add-ons`_
+use `Sass <https://sass-lang.com/>`_ as the preprocessor of choice. It may
+be useful to learn Sass as well.
+
+.. _new front-end to Firefox Add-ons: https://github.com/mozilla/addons-frontend
 
 
 A Few Words About Stylus
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 On the `Stylus website <http://stylus-lang.com/>`_, right at the top
-of the home page, the creators crow a lot about how all these required CSS
-syntax bits, like braces and colons and semicolons, are optional in Stylus, as
+of the home page, the creators exclaim how all the required CSS syntax bits,
+like braces and colons and semicolons, are optional in Stylus, as
 if they're a great annoyance that we've all been clamoring to abolish for years.
 
 Well, Stylus still generates ordinary CSS in the end, and inserts all those
@@ -589,9 +602,9 @@ especially if they make style sheets easier to read. For the sake of readability
 and smoother collaboration, we should try to make CSS look like CSS.
 
 Format your Stylus-flavored pre-processed files as if you were formatting
-vanilla CSS. Do use mixins, variables, functions, etc. and take advantage of all
-the flexible goodness Stylus offers, but it should still read like a CSS
-document.
+vanilla CSS. Do use mixins, variables, functions, etc., and take advantage of
+all the flexible goodness Stylus has to offer, but make sure that your CSS
+files still read like a CSS document.
 
 * Use CSS syntax (Stylus allows it).
 * Include colons, semi-colons, and braces.
@@ -617,50 +630,44 @@ document.
     }
 
 
-A Note on Sass/SCSS/Compass
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Very few (if any?) Mozilla projects use `Sass <https://sass-lang.com>`_ because
-it requires Ruby. While Sass is a fine tool, and can be awesome in combination
-with Compass, adding Ruby to our dev stack is a bridge too far. Sorry Rubyists;
-we're a Python shop.
-
-Even so, all the same formatting and organizational guidelines can apply just
-as well to Sass/SCSS. Live long and prosper.
+Note that all the same formatting and organizational guidelines can apply to
+both Sass and Sassy CSS (SCSS) as well.
 
 
 Validate!
 ---------
 
-Validate your CSS with the `W3C's online tool <https://github.com/w3c/css-validator>`_
-or equivalent.
+Validate your CSS with the `W3C CSS Validation Service`_ or equivalent.
 
-Validation tools may report errors or give warnings for vendor prefixes, as they
-should. It's something to be mindful of but it's perfectly fine to use prefixed
-properties if you're doing it right.
+Note that validation tools may report errors or give warnings for vendor
+prefixes since they aren't officially supported, but it's perfectly fine
+to use prefixed properties if you're doing it right.
 
 Validation *warnings* are very different from validation *errors*. You should
 take warnings under consideration and address them if needed, but errors are
 real problems that you need to fix.
 
-If you're using a preprocessor you'll obviously only be able to validate the
-generated plain CSS, which can make it harder to track down where the errors
-appear in the source files. A well organized style sheet can ease the pain.
+If you're using a CSS preprocessor, you'll only be able to validate the output
+CSS, which can make it harder to track down where the errors appear in the
+source files. A well organized style sheet makes this debugging process a lot
+easier.
+
+.. _W3C CSS Validation Service: https://github.com/w3c/css-validator
 
 
 A Note on CSS Lint
 ~~~~~~~~~~~~~~~~~~
 
 `CSS Lint <http://csslint.net/>`_ is a useful tool and we recommend it, but take
-its results with a grain of salt. Many of Lint's rules are phrased like
-absolute edicts when they're more like soft warnings of things to be mindful of
-(e.g. "Don't use too many floats"). Lint also forbids some things we expressly
-allow in our own guidelines (e.g. "Don't use ID selectors"). If your file gets a
-slew of warnings from CSS Lint that doesn't mean it's bad, just be able to
-justify your decisions.
+its results with a grain of salt. Many CSS Lint rules are phrased like laws when
+they're more like soft warnings of things to be mindful of (e.g. "Don't use too
+many floats"). CSS Lint also forbids some things we expressly allow in our own
+guidelines (e.g. "Don't use ID selectors"). If your file gets a slew of warnings
+from CSS Lint, that doesn't mean it's bad, just be able to justify your
+decisions.
 
-`This shortcut to CSS Lint`_ disables some of the more stringent rules we don't
-necessarily abide.
+`This shortcut to CSS Lint`_ disables some of the more opinionated rules we don't
+necessarily abide to.
 
 .. _This shortcut to CSS Lint: http://csslint.net/#warnings=display-property-grouping,duplicate-properties,empty-rules,known-properties,adjoining-classes,compatible-vendor-prefixes,vendor-prefix,fallback-colors,star-property-hack,underscore-property-hack,bulletproof-font-face,font-faces,universal-selector,unqualified-attributes,zero-units,overqualified-elements,shorthand,floats,important,outline-none
 

--- a/reference/css-style.rst
+++ b/reference/css-style.rst
@@ -11,7 +11,9 @@ Just so we all know what we're talking about, a CSS *rule* comprises one or more
 *declarations*. A declaration comprises a *property* and a *value* (some
 properties accept multiple values).
 
-A rule in CSS looks like this::
+A rule in CSS looks like this:
+
+.. code-block:: css
 
     selector {
         property: value;
@@ -56,7 +58,9 @@ syntax`_ unless, for some reason, you need to target old versions of Safari.
 .. _old Webkit syntax: https://www.webkit.org/blog/175/introducing-css-gradients/
 
 Practice progressive enhancement! Include solid fallback colors for old
-browsers that don't support ``rgba()`` or gradients::
+browsers that don't support ``rgba()`` or gradients:
+
+.. code-block:: css
 
     .widget {
         background: #ccc;
@@ -105,7 +109,9 @@ single element just for an easy style hook, or by creating oodles of generic
 classes to apply fine-grained styling at the expense of requiring a string of
 classes on each element in the markup.
 
-**Bad:** ::
+**Bad:**
+
+.. code-block:: css
 
     /* Too specific */
     .module-news-title-main {
@@ -130,7 +136,9 @@ to make every possible style rule free-standing and every element 100% reusable
 in any context on any page. Use descendant selectors as needed, but keep them
 simple.
 
-**Good:** ::
+**Good:**
+
+.. code-block:: css
 
     .module-news h2 {
         font: 20px 'League Gothic', sans-serif;
@@ -191,7 +199,9 @@ Use "`bulletproof font syntax`_" for webfonts. You usually don't need to include
 SVG font files unless your project needs to target older versions of WebKit.
 For modern browsers, TTF + WOFF is sufficient, as well as EOT for older
 versions of IE (which may also be optional, depending on your target audience).
-Example::
+Example:
+
+.. code-block:: css
 
     @font-face {
         font-family: 'Open Sans';
@@ -227,7 +237,9 @@ In general, when you're writing CSS, you should follow the following rules:
 * Put the closing brace (``}``) on its own line, aligned with the rule's
   selector.
 
-Here's an example::
+Here's an example:
+
+.. code-block:: css
 
     .selector-1,
     .selector-2 {
@@ -243,13 +255,17 @@ When you have a block of related rules, each with one or two declarations,
 you can use a single-line format without any blank lines between rules. This
 makes the block of related rules a bit easier to scan. When doing so, include
 a single space after the opening brace and before the closing brace. Add
-spaces after the selector to align the values, like so::
+spaces after the selector to align the values, like so:
+
+.. code-block:: css
 
     .message-success { color: #080; }
     .message-error   { color: #ff0; }
     .message-notice  { color: #00f; }
 
-Here's another example::
+Here's another example:
+
+.. code-block:: css
 
     @keyframes bounce {
         0%   { bottom: 300px; }
@@ -267,7 +283,9 @@ well within 80 characters even with indentation.
 Long, comma-separated property values---such as multiple background images,
 gradients, transforms, transitions, webfonts, or text and box shadows---can
 be arranged across multiple lines (indented one level from their property),
-as seen below::
+as seen below:
+
+.. code-block:: css
 
     .selector {
         background-image:
@@ -282,7 +300,9 @@ as seen below::
     }
 
 For vendor prefixed properties, use spaces to align the values, keeping the
-property names left-aligned as usual::
+property names left-aligned as usual:
+
+.. code-block:: css
 
     .selector {
         -webkit-box-shadow: 1px 2px 0 #ccc;
@@ -292,7 +312,9 @@ property names left-aligned as usual::
         box-shadow:         1px 2px 0 #ccc;
     }
 
-Or, when the value has the prefix::
+Or, when the value has the prefix:
+
+.. code-block:: css
 
     .selector {
         background: -webkit-linear-gradient(to bottom, #fff, #000);
@@ -364,11 +386,15 @@ and button styles. If you're using such a framework, you can use those classes
 as mixins in a preprocessed style sheet, rather than littering markup
 with presentational names.
 
-**Bad**::
+**Bad**:
+
+.. code-block:: html
 
     <div class="author-bio col-md-3 col-md-offset-2">
 
-**Better**::
+**Better**:
+
+.. code-block:: scss
 
     .author-bio {
         .col-md-3;
@@ -478,7 +504,9 @@ All the declarations for the parent element should come before the nested rules.
 Include a blank line before each nested rule to separate it from the rule or
 declaration above it.
 
-**Really Bad**::
+**Really Bad**:
+
+.. code-block:: scss
 
     .wrapper {
         #sidebar {
@@ -496,7 +524,9 @@ declaration above it.
         }
     }
 
-**Good**::
+**Good**:
+
+.. code-block:: scss
 
     .module-news {
         background: #ccc;
@@ -513,7 +543,7 @@ deeper than three levels, you probably need to reconsider your approach.
 If you wouldn't need to use a descendent selector in vanilla CSS, you probably
 don't need to nest it in a pre-processed style sheet.
 
-::
+.. code-block:: scss
 
     /* Unnecessary nesting; the nested class doesn't need the specificity */
     .module {
@@ -538,7 +568,7 @@ don't need to nest it in a pre-processed style sheet.
 If the parent rule has no declarations, nesting isn't necessary at all. If you
 need the specificity, use an ordinary descendant selector.
 
-::
+.. code-block:: scss
 
     /* Especially unnecessary nesting */
     .breadcrumbs {
@@ -612,7 +642,9 @@ files still read like a CSS document.
   but makes variables easier to spot by humans.
 
 
-**Bad** (though valid in Stylus)::
+**Bad** (though valid in Stylus):
+
+.. code-block:: scss
 
     .module
         background light-background
@@ -620,12 +652,14 @@ files still read like a CSS document.
             font-size h-medium
 
 
-**Good** (and still valid in Stylus)::
+**Good** (and still valid in Stylus):
+
+.. code-block:: scss
 
     .module {
-        background: $light-background;
+        background: var(--light);
         h2 {
-            font-size: $h-medium;
+            font-size: var(--medium);
         }
     }
 

--- a/reference/git_github.rst
+++ b/reference/git_github.rst
@@ -1,9 +1,9 @@
-
 Git and GitHub
 ==============
 
 This document describes some tips and tricks for using Git and GitHub.
-There are also some best practices for :ref:`best-practices-github`.
+You may also want to read through the best practices for both
+:ref:`best-practices-github`.
 
 Commit Messages
 ---------------
@@ -11,11 +11,15 @@ Commit Messages
 See `Tim Pope's blog post on git commit messages
 <http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html>`_.
 
+Chris Beams' `How to Write a Git Commit Message`_ may also be useful.
+
+.. _How to Write a Git Commit Message: https://chris.beams.io/posts/git-commit/
+
 Rebasing Commits
 ----------------
 
 While projects vary in their opinions on whether merge commits should be
-avoided or not, it is generally a good idea to rebase a feature branch before
+avoided or not, it is generally a good idea to `rebase`_ a feature branch before
 submitting a pull request.
 
 Rebasing allows you to alter a series of commits, changing the history of your
@@ -30,6 +34,8 @@ repository. Typically you rebase a branch to:
 
 These changes all make the code review process as well as the merging process
 easier, and are recommended for all pull requests.
+
+.. _rebase: https://git-scm.com/book/en/v2/Git-Branching-Rebasing
 
 .. warning:: Rebasing code that has already been pushed to a public or shared
              repository makes it very difficult for others to update their
@@ -46,8 +52,8 @@ Asking for Review
 -----------------
 
 When asking someone for a code review, it is recommended to add a new comment
-to a pull request using the ``@Username`` syntax. This notifies them via email
-that a review has been requested. Adding the ``@Username`` to the pull request
+to a pull request using the ``@username`` syntax. This notifies them via email
+that a review has been requested. Adding their ``@username`` to the pull request
 description will **not** send out the notification and thus isn't recommended.
 
 You may also add an attachment to a bug in Bugzilla and paste in the URL for

--- a/reference/html-style.rst
+++ b/reference/html-style.rst
@@ -11,7 +11,7 @@ General Guidelines
 - Make sure your code validates.
 - No inline CSS or JavaScript.
 - Be semantic.
-- Use doublequotes for attributes::
+- Use double quotes for attributes::
 
       <a href="#">Good</a>
       <a href='#'>Less Good</a>

--- a/reference/html-style.rst
+++ b/reference/html-style.rst
@@ -11,7 +11,9 @@ General Guidelines
 - Make sure your code validates.
 - No inline CSS or JavaScript.
 - Be semantic.
-- Use double quotes for attributes::
+- Use double quotes for attributes:
+
+  .. code-block:: html
 
       <a href="#">Good</a>
       <a href='#'>Less Good</a>

--- a/reference/index.rst
+++ b/reference/index.rst
@@ -1,8 +1,7 @@
 Reference
 =========
 
-This is where all the useful information goes that doesn't fit into the
-:doc:`/guide/index`.
+Here you'll find other useful information not found in the :doc:`/guide/index`.
 
 .. toctree::
    :maxdepth: 1

--- a/reference/js-style.rst
+++ b/reference/js-style.rst
@@ -126,8 +126,6 @@ Space after keyword, and space before curly
 Functions
 ---------
 
-.. _named-functions:
-
 Named Functions
 ~~~~~~~~~~~~~~~
 

--- a/reference/js-style.rst
+++ b/reference/js-style.rst
@@ -10,10 +10,9 @@ First and Foremost
 
 .. Note::
 
-   There are some exceptions for which JSHint complains about things in node
-   that you can ignore, like how it doesn't know what 'const' is and complains
-   about not knowing what 'require' is. You can add keywords to ignore to a
-   `.jshintrc` file.
+   JSHint may warn about some features of Node.js that aren't present in your
+   typical browser implementation of JavaScript. These can be safely ignored.
+   You can ignore some JSHint warnings permanently with a `.jshintrc` file.
 
 .. _JSHint: http://www.jshint.com/
 
@@ -30,11 +29,7 @@ Variable Formatting:
     var myVariable = ...
 
     // Constants: UPPER_CASE_WITH_UNDERSCORES
-    // Backend
     const MY_CONST = ...
-
-    // Client-side
-    var MY_CONST = ...
 
 
 Indentation
@@ -59,8 +54,8 @@ Use ``[]`` to assign a new array, not ``new Array()``.
 
 Use ``{}`` for new objects, as well.
 
-Two scenarios for ``[]`` (one can be on the same line, with discretion
-and the other not so much)::
+The array literal ``[]`` can be used with either a single line or multiple
+lines, depending how easy it is to read::
 
     // Okay on a single line
     var stuff = [1, 2, 3];
@@ -75,15 +70,15 @@ and the other not so much)::
 Never assign multiple variables on the same line
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Bad::
+Example of what not to do::
 
-    var a = 1, b = 'foo', c = 'wtf';
+    var a = 1, b = 'foo', c = 'don\'t do this';
 
 
 DO NOT line up variable names
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Bad::
+For consistency, don't do this::
 
     var wut    = true;
     var boohoo = false;
@@ -94,8 +89,8 @@ Semi-colons
 
 **Use them.**
 
-Not because ASI is black-magic, or whatever. I'm sure we all understand ASI.
-Just do it for consistency.
+Even though JavaScript can use automatic semicolon insertion (ASI), you should
+still use semi-colons to be consistent with the rest of the codebase.
 
 
 Conditionals and Loops
@@ -119,12 +114,12 @@ Space after keyword, and space before curly
 
     // Bad
     if(bad){
-
+        // This is bad
     }
 
     // Good
     if (something) {
-
+        // This is better
     }
 
 
@@ -136,35 +131,46 @@ Functions
 Named Functions
 ~~~~~~~~~~~~~~~
 
-There's no need to explicitly name a function when you're already
-assigning it to a descriptively named symbol::
+You should assign functions to named symbols, like so::
 
     var updateOnClick = function() { ... };
 
-...or... ::
+Here, the function above is known as ``updateOnClick``. The same can be done
+with objects. In the example below, ``someObject.updateOnClick`` is the
+function::
 
-    var someObject = {updateOnClick: function() { ... }
+    var someObject = {
+        updateOnClick: function() { ... }
+    };
 
-Most modern JS engines will infer the name *updateOnClick* for the above
-anonymous function and use it in tracebacks.
+If you're passing a nontrivial function as an argument, you should name it to
+avoid obscuring what it's supposed to do.
 
-Of course, if you're passing a nontrivial function as an argument, you
-should still contrive to name it somehow. The meaning here would be
-needlessly obscured if the anonymous function were, for example, 10 lines long::
+Don't do this::
 
-    .forEach(function() { ... })
+    obj.forEach(function(item) {
+        // A large anonymous function with dozens of lines of code.
+        // This makes it hard to understand what the function does
+        // without reading through it entirely.
+    });
 
-In such cases, either name the function, or pass a descriptively named
-symbol that points to a function.
+Instead, do the following::
+
+    var doMagic = function(item) { ... };
+
+    obj.forEach(doMagic);
+
+Here, it is easy to see that ``doMagic`` gets called for each object.
 
 
 Whitespacing Functions
 ~~~~~~~~~~~~~~~~~~~~~~
 
-No space between name and opening paren. Space between closing paren and brace::
+Do not put a space between "function" and the opening parenthesis. Do put a
+space after the closing parenthesis and before the opening curly brace::
 
     var method = function(argOne, argTwo) {
-
+        // Do something
     };
 
 
@@ -172,21 +178,21 @@ Anonymous Functions
 ~~~~~~~~~~~~~~~~~~~
 
 Anonymous functions are fine if they have a small amount of code in them. See
-the :ref:`named-functions` section for info about inferred function names for
-anonymous functions.
+the :ref:`named-functions` section for more information about inferred function
+names for anonymous functions.
 
 
 Operators
 ---------
 
-Always use ``===``.
+Always use strict equality (``===``).
 
-Only exception is when testing for null and undefined.
+The only exception to this rule is when testing for null and undefined.
 
 Example::
 
     if (value != null) {
-
+        // This is an exception to the rule. Usually you'd use !==
     }
 
 
@@ -195,13 +201,13 @@ Quotes
 
 Always use single quotes: ``'not double'``
 
-Only exception: ``"don't escape single quotes in strings. use double quotes"``
+There is only one exception: ``"don't escape single quotes in strings; use double quotes instead"``
 
 
 Comments
 --------
 
-For node functions, always provide a clear comment in this format::
+For Node.js functions, always provide a clear comment in this format::
 
     /* Briefly explains what this does
      * Expects: whatever parameters
@@ -209,18 +215,19 @@ For node functions, always provide a clear comment in this format::
      */
 
 
-If comments are really long, also do it in the ``/* ... */`` format like above.
-Otherwise make short comments like::
+If your comment is really long, use the format mentioned above (``/* ... */``).
+Otherwise make short comments like so::
 
-    // This is my short comment and it ends in a period.
+    // This is a short comment that ends in a period.
 
 
 Ternaries
 ---------
 
-Try not to use them.
+Avoid using the ternary operator (``(condition) ? (true) : (false)``).
 
-If a ternary uses multiple lines, don't use a ternary::
+If using the ternary operator makes a line particularly complex, or would
+require using multiple lines, don't use it::
 
     // Bad
     var foo = (user.lastLogin > new Date().getTime() - 16000) ? user.lastLogin - 24000 : 'wut';
@@ -232,22 +239,20 @@ If a ternary uses multiple lines, don't use a ternary::
 General Good Practices
 ----------------------
 
-If you see yourself repeating something that can be a constant, refactor it as a
-single constant declaration at the top of the file.
-
-Cache regex into a constant.
-
-Always check for truthiness::
+* Don't repeat yourself! If you see yourself repeating something that could be
+  a constant, refactor it as a single constant declaration at the top of the
+  file.
+* Try caching your regular expressions (regex) by declaring them as constants.
+* Always check for truthiness::
 
     // Bad
-    if (blah !== false) { ...
+    if (blah !== false) { ... }
 
     // Good
-    if (blah) { ...
+    if (blah) { ... }
 
-
-If code is really long, try to break it up to the next line or refactor (try to
-keep within the 80-col limit but if you go a bit past it's not a big deal).
-Indent the subsequent lines one indent (2-spaces) in.
-
-If it looks too clever, it probably is, so just make it simple.
+* If one line in your code is really long, you should probably refactor it. If
+  this isn't possible, try breaking it up into multiple lines.
+* Try to keep within the 80-column limit (but if you go a bit past it's not a
+  big deal). Indent the subsequent lines one indent (2-spaces) in.
+* If it looks too clever, it probably is, so just make it simple.

--- a/reference/js-style.rst
+++ b/reference/js-style.rst
@@ -20,7 +20,7 @@ First and Foremost
 Variable Formatting:
 --------------------
 
-::
+.. code-block:: javascript
 
     // Classes: CapitalizedWords
     var MyClass = ...
@@ -37,7 +37,9 @@ Indentation
 
 4-space indents (no tabs).
 
-For our projects, always assign var on a newline, not comma separated::
+For our projects, always assign var on a newline, not comma separated:
+
+.. code-block:: javascript
 
     // Bad
     var a = 1,
@@ -55,7 +57,9 @@ Use ``[]`` to assign a new array, not ``new Array()``.
 Use ``{}`` for new objects, as well.
 
 The array literal ``[]`` can be used with either a single line or multiple
-lines, depending how easy it is to read::
+lines, depending how easy it is to read:
+
+.. code-block:: javascript
 
     // Okay on a single line
     var stuff = [1, 2, 3];
@@ -70,7 +74,9 @@ lines, depending how easy it is to read::
 Never assign multiple variables on the same line
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Example of what not to do::
+Example of what not to do:
+
+.. code-block:: javascript
 
     var a = 1, b = 'foo', c = 'don\'t do this';
 
@@ -78,7 +84,9 @@ Example of what not to do::
 DO NOT line up variable names
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For consistency, don't do this::
+For consistency, don't do this:
+
+.. code-block:: javascript
 
     var wut    = true;
     var boohoo = false;
@@ -96,7 +104,7 @@ still use semi-colons to be consistent with the rest of the codebase.
 Conditionals and Loops
 ----------------------
 
-::
+.. code-block:: javascript
 
     // Bad
     if (something) doStuff()
@@ -110,7 +118,7 @@ Conditionals and Loops
 Space after keyword, and space before curly
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-::
+.. code-block:: javascript
 
     // Bad
     if(bad){
@@ -129,13 +137,17 @@ Functions
 Named Functions
 ~~~~~~~~~~~~~~~
 
-You should assign functions to named symbols, like so::
+You should assign functions to named symbols, like so:
+
+.. code-block:: javascript
 
     var updateOnClick = function() { ... };
 
 Here, the function above is known as ``updateOnClick``. The same can be done
 with objects. In the example below, ``someObject.updateOnClick`` is the
-function::
+function:
+
+.. code-block:: javascript
 
     var someObject = {
         updateOnClick: function() { ... }
@@ -144,7 +156,9 @@ function::
 If you're passing a nontrivial function as an argument, you should name it to
 avoid obscuring what it's supposed to do.
 
-Don't do this::
+Don't do this:
+
+.. code-block:: javascript
 
     obj.forEach(function(item) {
         // A large anonymous function with dozens of lines of code.
@@ -152,7 +166,9 @@ Don't do this::
         // without reading through it entirely.
     });
 
-Instead, do the following::
+Instead, do the following:
+
+.. code-block:: javascript
 
     var doMagic = function(item) { ... };
 
@@ -165,7 +181,9 @@ Whitespacing Functions
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Do not put a space between "function" and the opening parenthesis. Do put a
-space after the closing parenthesis and before the opening curly brace::
+space after the closing parenthesis and before the opening curly brace:
+
+.. code-block:: javascript
 
     var method = function(argOne, argTwo) {
         // Do something
@@ -187,7 +205,9 @@ Always use strict equality (``===``).
 
 The only exception to this rule is when testing for null and undefined.
 
-Example::
+Example:
+
+.. code-block:: javascript
 
     if (value != null) {
         // This is an exception to the rule. Usually you'd use !==
@@ -205,7 +225,9 @@ There is only one exception: ``"don't escape single quotes in strings; use doubl
 Comments
 --------
 
-For Node.js functions, always provide a clear comment in this format::
+For Node.js functions, always provide a clear comment in this format:
+
+.. code-block:: javascript
 
     /* Briefly explains what this does
      * Expects: whatever parameters
@@ -214,7 +236,9 @@ For Node.js functions, always provide a clear comment in this format::
 
 
 If your comment is really long, use the format mentioned above (``/* ... */``).
-Otherwise make short comments like so::
+Otherwise make short comments like so:
+
+.. code-block:: javascript
 
     // This is a short comment that ends in a period.
 
@@ -225,7 +249,9 @@ Ternaries
 Avoid using the ternary operator (``(condition) ? (true) : (false)``).
 
 If using the ternary operator makes a line particularly complex, or would
-require using multiple lines, don't use it::
+require using multiple lines, don't use it:
+
+.. code-block:: javascript
 
     // Bad
     var foo = (user.lastLogin > new Date().getTime() - 16000) ? user.lastLogin - 24000 : 'wut';
@@ -241,13 +267,15 @@ General Good Practices
   a constant, refactor it as a single constant declaration at the top of the
   file.
 * Try caching your regular expressions (regex) by declaring them as constants.
-* Always check for truthiness::
+* Always check for truthiness:
 
-    // Bad
-    if (blah !== false) { ... }
+  .. code-block:: javascript
 
-    // Good
-    if (blah) { ... }
+      // Bad
+      if (blah !== false) { ... }
+
+      // Good
+      if (blah) { ... }
 
 * If one line in your code is really long, you should probably refactor it. If
   this isn't possible, try breaking it up into multiple lines.

--- a/reference/l10n.rst
+++ b/reference/l10n.rst
@@ -2,17 +2,17 @@ Internationalization (i18n) and Localization (L10n)
 ===================================================
 
 Mozilla is a global community, and most of our websites are localized, meaning
-that they are available in multiple languages for users across the world.
+that they are available in multiple languages for many users across the world.
 
 Internationalization is the process of designing software so that it may be
-adapted to different languages and regions, whereas localization is the actual
-process of adapting that software to a specific locale.
+adapted to different languages and regions, whereas localization is the process
+of actually adapting that software to a specific locale.
 
 This document describes what you need to be aware of while developing software
 intended for a global community.
 
-.. note:: The examples in this document are using `Jinja2`_ syntax. While the
-   concepts are generally the same, the exact syntax may differ between
+.. note:: The examples in this document are using the `Jinja2`_ syntax. While
+   the concepts are generally the same, the exact syntax may differ between
    projects.
 
    There are also a few `jingo`_-specific filters being used. Again, be sure
@@ -61,8 +61,8 @@ display different text depending on the user's locale. The text that is shown
 is stored in a file that maps the English text to the translated text. It is
 this file that localizers produce when translating a site.
 
-There are several different file formats for translation files, but the most
-common ones are:
+There are several different file formats for translation files, but here are
+the most common ones:
 
 - `PO files`_ are a format supported by the `GNU gettext`_ program, and are
   very common and well-supported by tools.

--- a/reference/python-style.rst
+++ b/reference/python-style.rst
@@ -44,20 +44,19 @@ third-party; and local imports::
     from myapp import models, views
 
 
-Alphabetize your imports, it will make your code easier to scan. See how
-terrible this is::
+Alphabetize your imports, it will make your code easier to scan. Compare::
 
     import cows
     import kittens
     import bears
 
-A simple sort::
+This is much easier to read with a simple sort::
 
     import bears
     import cows
     import kittens
 
-Imports on top, ``from``-imports below::
+Use ``import`` statements on top, before ``from``-imports, like so::
 
     import x
     import y
@@ -66,7 +65,7 @@ Imports on top, ``from``-imports below::
     from xylophone import bar
     from zoos import lions
 
-That's loads easier to read than::
+That's a lot easier to read than::
 
     from bears import pandas
     import x
@@ -83,7 +82,7 @@ alphabetized ``CONSTANT``, ``Class``, ``var`` order::
 
 
 If possible though, it may be easier to import the entire package, especially
-for methods as it help answers the question, "where did ``you`` come from?"
+for methods, as it help answers the question, "where did ``you`` come from?"
 
 Bad::
 
@@ -116,30 +115,30 @@ Whitespace matters
 
 Use single quotes unless double (or triple) quotes would be an improvement::
 
-    'this is good'
+    'do this'
 
-    'this\'s bad'
+    'but don\'t do this'
 
-    "this's good"
+    "it's best to avoid escaping '"
 
     "this is inconsistent, but ok"
 
-    """this's sometimes "necessary"."""
+    """sometimes it's "necessary" to do this"""
 
     '''nobody really does this'''
 
-To continue a new line use a ```()``` not ```\```.
+To continue a new line, use ```()``` instead of ```\```.
 
 Indenting code should be done in one of two ways: a hanging indent, or 4 space
 indent on the next line.
 
-Good, using hanging indent. Note that the next line is lined up with the
-previous line delimiter::
+Here is a good example using hanging indent. Note that the next line is lined
+up with the previous line delimiter::
 
     log.msg('Something long log message and some vars: {0}, {1}'
             .format(variable_a, variable_b))
 
-Good using 4 spaces::
+Another good example, this time using 4 spaces::
 
     accounts = PaymentAccounts.objects.filter(
         accounts__provider__type=2,

--- a/reference/security.rst
+++ b/reference/security.rst
@@ -96,12 +96,12 @@ Projects simplifying the use of CSP
 * Node.js/Express: https://github.com/evilpacket/helmet
 
 
-.. _`wide adoption among browsers`: https://caniuse.com/#search=content%20security%20policy
-.. _`Content Security Policy`: https://www.w3.org/TR/CSP2/
-.. _`CSP 3.0`: https://www.w3.org/TR/CSP3/
-.. _`MDN`: https://developer.mozilla.org/docs/Security/CSP
-.. _`Security Review Process`: https://wiki.mozilla.org/Security/ReviewProcess
-.. _`blog post`: https://blog.mozilla.org/security/2013/12/12/on-the-x-frame-options-security-header/
-.. _`XFO on MDN`: https://developer.mozilla.org/docs/HTTP/X-Frame-Options
-.. _`Django`: https://docs.djangoproject.com/en/dev/ref/clickjacking/
-.. _`Node.js`: https://npmjs.org/package/helmet
+.. _wide adoption among browsers: https://caniuse.com/#search=content%20security%20policy
+.. _Content Security Policy: https://www.w3.org/TR/CSP2/
+.. _CSP 3.0: https://www.w3.org/TR/CSP3/
+.. _MDN: https://developer.mozilla.org/docs/Security/CSP
+.. _Security Review Process: https://wiki.mozilla.org/Security/ReviewProcess
+.. _blog post: https://blog.mozilla.org/security/2013/12/12/on-the-x-frame-options-security-header/
+.. _XFO on MDN: https://developer.mozilla.org/docs/HTTP/X-Frame-Options
+.. _Django: https://docs.djangoproject.com/en/dev/ref/clickjacking/
+.. _Node.js: https://npmjs.org/package/helmet

--- a/reference/security.rst
+++ b/reference/security.rst
@@ -27,7 +27,7 @@ If you do need to be framed, you can restrict this to web pages in the same
 origin (people sometimes think "same domain", but it's actually the protocol,
 domain name and port forming the security scope of a website).
 There are detailed docs about `XFO on MDN`_ and there are additional resources
-that show you how to set up X-Frame-Options in your `Django`_ and `NodeJS`_
+that show you how to set up X-Frame-Options in your `Django`_ and `Node.js`_
 projects.
 
 
@@ -44,8 +44,8 @@ Content Security Policy
 some client-side attacks on web applications, like Cross-Site Scripting (XSS).
 Think of CSP as a whitelist of resources which are allowed to be embedded into
 your HTML documents. As CSP does not prevent flaws from being exploited but merely
-mitigates the effects, you should never solely rely on it. `CSP 1.1`_ is already
-being drafted at the W3C, but you should focus on CSP 1.0 - mainly because of
+mitigates the effects, you should never solely rely on it. `CSP 3.0`_ is already
+being drafted at the W3C, but you should focus on CSP 2.0 - mainly because of
 its `wide adoption among browsers`_. Head on over to `MDN`_ for more information
 on this topic.
 
@@ -77,15 +77,15 @@ Here are some strategies for avoiding common CSP errors:
 :Inline script elements:
     Should go into a JS file.
 :Inline event handlers:
-    Attach event handler in an external JS file (addEventListener) or let event
-    bubbling work for you (e.g. JQuery's $.live).
+    Attach event handler in an external JS file (``addEventListener``) or let event
+    bubbling work for you (e.g. jQuery's ``$.live``).
 :JS pseudo protocol:
     Attach click event handler to the node (see above)
 :Inline style elements:
     These can be easily put into an external CSS file
 :Inline style attributes:
     Add classes or IDs to your markup and handle those in an external CSS file
-:Inline style attributes which are set via JavaScript:
+:Inline style attributes set via JavaScript:
     Use the ``element.style`` property instead of ``element.setAttribute``.
 
 
@@ -97,11 +97,11 @@ Projects simplifying the use of CSP
 
 
 .. _`wide adoption among browsers`: https://caniuse.com/#search=content%20security%20policy
-.. _`Content Security Policy`: https://www.w3.org/TR/CSP/
-.. _`CSP 1.1`: https://dvcs.w3.org/hg/content-security-policy/raw-file/tip/csp-specification.dev.html
+.. _`Content Security Policy`: https://www.w3.org/TR/CSP2/
+.. _`CSP 3.0`: https://www.w3.org/TR/CSP3/
 .. _`MDN`: https://developer.mozilla.org/docs/Security/CSP
 .. _`Security Review Process`: https://wiki.mozilla.org/Security/ReviewProcess
 .. _`blog post`: https://blog.mozilla.org/security/2013/12/12/on-the-x-frame-options-security-header/
 .. _`XFO on MDN`: https://developer.mozilla.org/docs/HTTP/X-Frame-Options
 .. _`Django`: https://docs.djangoproject.com/en/dev/ref/clickjacking/
-.. _`NodeJS`: https://npmjs.org/package/helmet
+.. _`Node.js`: https://npmjs.org/package/helmet

--- a/reference/servers.rst
+++ b/reference/servers.rst
@@ -10,7 +10,7 @@ Development, staging, and production
 
 Most Mozilla websites are split into three environments:
 
-- Development (AKA Dev) usually runs off of the latest code that has been
+- Development (AKA dev) usually runs off of the latest code that has been
   committed for a project by updating regularly throughout the day. Dev is
   useful for testing new features and getting feedback.
 

--- a/reference/testing.rst
+++ b/reference/testing.rst
@@ -27,45 +27,48 @@ than others. Also, some parts of your project are more important than others,
 and it may be more harmful for them to fail than less important parts.
 
 A risk assessment lists out the different parts of your project (such as
-certain webpages or parts of an API) and ranks them based on their importance.
-For example, a news site rank being able to read existing articles as more
-important than being able to submit new articles. Ranking these parts allows
-you to make decisions about which to test more and what kind of tests to run.
+certain web pages or parts of an API) and ranks them based on their importance.
+For example, a news site would rank being able to read existing articles as more
+important than being able to submit new articles. This kind of ranking allows
+you to make better decisions about which parts of your project to test more and
+what kind of tests to run.
 
 Unit and integration tests
 --------------------------
 
-As a developer, the most common type of tests you will write are unit and
+As a developer, the most common type of tests you will write are unit tests and
 integration tests. Unit tests test the smallest possible chunk of functionality
-and are isolated from eachother. Integration tests test the interaction between
-these chunks.
+and are isolated from each other, whereas integration tests test the interaction
+between these chunks.
 
 In practice, **any changes you make to a project should be tested in some
 automated way if it's reasonable to do so.** While each project varies,
 generally Webdev isn't picky about having perfect unit tests or perfect test
-isolation. If you're unsure, look at existing tests for the project for
+isolation. If you're unsure, look at the project's existing tests for
 guidance on the preferred style.
 
-Mozilla runs a `Jenkins server <https://ci.mozilla.org/>`_ for running these
-tests automatically for several projects. Other projects rely on `Travis CI`_
-for executing their tests.
+Mozilla uses `TaskCluster`_ to run these tests automatically for continuous
+integration. Other projects rely on `Travis CI`_ for executing their tests.
 
 For Django projects, these tests live within the ``tests`` module of each
 included Django application. For Node-based projects, they normally live in
 a directory named ``test`` or ``tests`` at the root of the repository. Refer to
 your project's documentation for more details.
 
+.. _TaskCluster: https://docs.taskcluster.net/
+
 End-to-end tests
 ----------------
 
-End-to-end tests simulates how your project will be used by users and verifies
+End-to-end tests simulate how your project will be used by end users and verify
 that it behaves as expected. This is most commonly applied to websites, where
-we use tools like Selenium_ to simulate users interacting with the website.
+we use tools like `Selenium`_ to simulate users interacting with the website.
 
-For many sites, these tests are written by WebQA contributors and run against
-the various :doc:`server environments <servers>`.
+For many sites, these tests are written by `Web QA`_ contributors and run
+against the various :doc:`server environments <servers>`.
 
 .. _Selenium: https://wiki.mozilla.org/Websites/Domain_List
+.. _Web QA: https://blog.mozilla.org/webqa/
 
 Manual testing
 --------------
@@ -105,8 +108,8 @@ Python
    - `nose-progressive`_ is a nose plugin that makes test output much easier
      to read.
 
-- `factory-boy`_ replaces test fixtures with factories that generate test
-  objects easily. It integrates with the Django ORM to generate model instances
+- `factory_boy`_ replaces test fixtures with factories that generate test
+  objects easily. It integrates with the `Django ORM`_ to generate model instances
   with a very convenient syntax.
 
 - Mock_ is one of the most popular libraries for replacing parts of the system
@@ -115,13 +118,14 @@ Python
 .. _nose: https://nose.readthedocs.io/
 .. _django-nose: https://github.com/django-nose/django-nose
 .. _nose-progressive: https://github.com/erikrose/nose-progressive
-.. _factory-boy: https://factoryboy.readthedocs.io/
+.. _factory_boy: https://factoryboy.readthedocs.io/
 .. _Mock: http://www.voidspace.org.uk/python/mock/
+.. _Django ORM: https://docs.djangoproject.com/en/2.0/topics/db/
 
 Node / JavaScript
 ^^^^^^^^^^^^^^^^^
 
-- Mocha_ is a framework for running tests on node.js and in the browser.
+- Mocha_ is a framework for running tests on Node.js and in the browser.
 - Chai_ is an assertion library with many interfaces to accommodate different
   testing styles.
 - Karma_ allows you to execute JavaScript code in multiple real browsers.


### PR DESCRIPTION
This is a big pull request. I basically read through the entire documentation (learning about the process), and tried to update or fix things as I came across them.

I learned a lot through both the Mozilla Webdev guides and trying to get certain parts of Sphinx to work. I tried to separate the commits to make it easier to review. Here's a summary of the changes I made, with references as needed:

- Updated the syntax of some links to be consistent with the Sphinx [documentation](http://www.sphinx-doc.org/en/stable/rest.html#hyperlinks) (should be fine since when I tested my changes, these links behaved the same)
- Fixed inconsistent spacing between periods
- Updated the Playdoh URL (the locale is required here)
- `s/git/Git/`
- Various wording changes; the general gist of things is that I tried to make things easier to read and understand
- Created lists for some sections
- Added `code` blocks for some code strings
- Changed the operating systems section to mention GNU/Linux
- Changed OS X to macOS
- Fixed some old information about GitHub Desktop
- Fixed code blocks not using the correct language
- Fixed some grammar issues
- Fixed some dashes not being consistent
- Added emphasis to the keyword `not` in one section
- Added spacing to several inline sections that looked weird without it
- `s/US English/American English/`
- Addressed the usage of Sass in more recent Mozilla projects
- `s/LESS/Less/`
- Changed the Stylus example to use CSS variables (`$` was making the syntax highlighter not work, even for valid Stylus / SCSS)
- Clarified some details on linting
- Added a few helpful links
- Clarified what ASI (automatic semicolon insertion) is (it's not an acronym people often remember)
- Changed some JavaScript examples to be easier to understand
- Added missing semicolons in some JavaScript examples
- Added the names of some symbols next to them
- Explained the ternary operator
- `s/NodeJS/Node.js/`
- Updated Content Security Policy (CSP) to mention CSP 2.0 (W3C Recommendation) and CSP 3.0 (W3C Working Draft)
- `s/JQuery/jQuery/`
- Updated the section on continuous integration
- Fixed more grammar issues as I found them