### PR TITLE
Fix the Playdoh URL for Sphinx

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -223,5 +223,5 @@ man_pages = [
 ]
 
 intersphinx_mapping = dict(
-    playdoh=('https://playdoh.readthedocs.io/', None)
+    playdoh=('https://playdoh.readthedocs.io/en/latest/', None)
     )


### PR DESCRIPTION
Specifying the "en" locale is necessary here since readthedocs.io does not gracefully load objects.inv (unfortunately, it 404s instead).

This is a part of #60.