### PR TITLE
Update the HTML Reference

### DIFF
--- a/reference/html-style.rst
+++ b/reference/html-style.rst
@@ -11,7 +11,9 @@ General Guidelines
 - Make sure your code validates.
 - No inline CSS or JavaScript.
 - Be semantic.
-- Use doublequotes for attributes::
+- Use double quotes for attributes:
+
+  .. code-block:: html
 
       <a href="#">Good</a>
       <a href='#'>Less Good</a>


### PR DESCRIPTION
Changed `doublequotes` to `double quotes` and fixed the syntax highlighting block.

This is a part of #60.