### PR TITLE
Fix the named functions reference

### DIFF
--- a/reference/js-style.rst
+++ b/reference/js-style.rst
@@ -134,6 +134,8 @@ Space after keyword, and space before curly
 Functions
 ---------
 
+.. _named-functions:
+
 Named Functions
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Didn't realize that Sphinx needed empty links like this to reference other sections. I tested my changes and it should be fixed now.